### PR TITLE
修复连点器基座刷物品

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import java.util.Optional;
 import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.api.events.PlayerRightClickEvent;
@@ -113,14 +114,25 @@ public class AncientAltarListener implements Listener {
             UUID uuid = stack.getUniqueId();
             removedItems.add(uuid);
 
-            Slimefun.runSync(() -> removedItems.remove(uuid), 30L);
-
-            stack.remove();
+            Slimefun.runSync(() -> removedItems.remove(uuid), 30L);  
+        	
             p.getInventory().addItem(fixItemStack(stack.getItemStack(), stack.getCustomName()));
             p.playSound(pedestal.getLocation(), Sound.ENTITY_ITEM_PICKUP, 1F, 1F);
-        }
+            removeDisplayItem(pedestal);
+        } 
     }
-
+    public static void removeDisplayItem(Block b) {
+        getEntity(b).ifPresent(Item::remove);
+    }
+    private static Optional<Item> getEntity(Block b) {
+    	for (Entity n : b.getChunk().getEntities()) {
+            if (n instanceof Item && b.getLocation().add(0.5, 1.2, 0.5).distanceSquared(n.getLocation()) < 1.0D && n.getCustomName() != null) {
+            	Item item = (Item) n;
+                return Optional.of(item);
+                }
+            }
+    	return Optional.empty();
+    }
     private void useAltar(Block b, Player p) {
         ItemStack catalyst = new CustomItem(p.getInventory().getItemInMainHand(), 1);
         List<Block> pedestals = getPedestals(b);
@@ -201,7 +213,6 @@ public class AncientAltarListener implements Listener {
             }
         }
     }
-
     public ItemStack fixItemStack(ItemStack itemStack, String customName) {
         ItemStack stack = itemStack.clone();
 
@@ -220,7 +231,7 @@ public class AncientAltarListener implements Listener {
 
     public Item findItem(Block b) {
         for (Entity n : b.getChunk().getEntities()) {
-            if (n instanceof Item && b.getLocation().add(0.5, 1.2, 0.5).distanceSquared(n.getLocation()) < 0.5D && n.getCustomName() != null) {
+            if (n instanceof Item && b.getLocation().add(0.5, 1.2, 0.5).distanceSquared(n.getLocation()) < 1.0D && n.getCustomName() != null) {
                 return (Item) n;
             }
         }


### PR DESCRIPTION
修复了: 如果一个人用10ms连点器右键基座导致基座上短时间出现多个物品，如果另一个人挖掉基座，就会刷物品的bug。
即使anti-altar-glitch为false,基座上有物品时可以破坏，也能防止刷物品。
可以防止基座非人为破坏导致的刷物品。