### PR TITLE
爆炸工具方块黑名单添加对木牌的支持

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
@@ -30,7 +30,7 @@ public class ExplosiveShovel extends ExplosiveTool {
 
     @Override
     protected void breakBlock(Player p, ItemStack item, Block b, int fortune, List<ItemStack> drops) {
-        if (!isUnbreakable(b.getType().name())
+        if (!isUnbreakable(b)
                 && ProtectionChecker.canInteract(p, b, ProtectableAction.BREAK_BLOCK)
                 && MaterialTools.getBreakableByShovel().contains(b.getType())
                 && SlimefunPlugin.getProtectionManager().hasPermission(p, b.getLocation(), ProtectableAction.BREAK_BLOCK)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -23,6 +23,7 @@ import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
@@ -111,7 +112,7 @@ class ExplosiveTool extends SimpleSlimefunItem<BlockBreakHandler> implements Not
     }
 
     protected void breakBlock(Player p, ItemStack item, Block b, int fortune, List<ItemStack> drops) {
-        if (!isUnbreakable(b.getType().name())
+        if (!isUnbreakable(b)
                 && ProtectionChecker.canInteract(p, b, ProtectableAction.BREAK_BLOCK)
                 && b.getType() != Material.AIR
                 && !b.isLiquid()
@@ -149,9 +150,16 @@ class ExplosiveTool extends SimpleSlimefunItem<BlockBreakHandler> implements Not
         }
     }
 
-    protected boolean isUnbreakable(String name) {
+    protected boolean isUnbreakable(Block b) {
         if (!unbreakableBlocks.getValue().isEmpty()) {
-            return unbreakableBlocks.getValue().contains(name);
+            for(String material : unbreakableBlocks.getValue()){
+                if(material.toUpperCase().equals("SIGN") && b.getState() instanceof Sign){
+                    return true;
+                }
+                if(b.getType().equals(Material.matchMaterial(material, true))){
+                    return true;
+                }
+            }
         }
         return false;
     }


### PR DESCRIPTION
爆炸镐会破坏箱子商店的箱子和木牌，所以添加了黑名单对木牌的支持