### PR TITLE
改回基座修复代码

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -368,7 +368,7 @@ public class AncientAltarListener implements Listener {
     }
 
     public boolean isUsing(Block pedestal, Location loc) {
-        if (loc == null || pedestal == null) {
+        if (loc == null) {
             return false;
         }
 


### PR DESCRIPTION
由于基座修复代码被修改，连点器基座刷物品bug重现了，原因是在被挖掉的瞬间pedestal就是null，如果此时判断不在使用，那么反刷物品就失效了。经过测试情况属实。改回就好了，无需担心基座是null的情况。