### PR TITLE
修复方块放置机刷物品bug

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
@@ -79,6 +79,12 @@ public class BlockPlacer extends SimpleSlimefunItem<BlockDispenseHandler> {
     }
 
     private void placeSlimefunBlock(SlimefunItem sfItem, ItemStack item, Block block, Dispenser dispenser) {
+        if (dispenser.getInventory().containsAtLeast(item, 2)) {
+            dispenser.getInventory().removeItem(new CustomItem(item, 1));
+        } else {
+            item.setAmount(0);
+        }
+        
         block.setType(item.getType());
         BlockStorage.store(block, sfItem.getID());
         block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, item.getType());
@@ -92,15 +98,15 @@ public class BlockPlacer extends SimpleSlimefunItem<BlockDispenseHandler> {
                 spawner.update(true, false);
             }
         }
-
-        if (dispenser.getInventory().containsAtLeast(item, 2)) {
-            dispenser.getInventory().removeItem(new CustomItem(item, 1));
-        } else {
-            Slimefun.runSync(() -> dispenser.getInventory().removeItem(item), 2L);
-        }
     }
 
     private void placeBlock(ItemStack item, Block facedBlock, Dispenser dispenser) {
+        if (dispenser.getInventory().containsAtLeast(item, 2)) {
+            dispenser.getInventory().removeItem(new CustomItem(item, 1));
+        } else {
+            item.setAmount(0);
+        }
+        
         facedBlock.setType(item.getType());
 
         if (item.hasItemMeta()) {
@@ -120,11 +126,5 @@ public class BlockPlacer extends SimpleSlimefunItem<BlockDispenseHandler> {
         }
 
         facedBlock.getWorld().playEffect(facedBlock.getLocation(), Effect.STEP_SOUND, item.getType());
-
-        if (dispenser.getInventory().containsAtLeast(item, 2)) {
-            dispenser.getInventory().removeItem(new CustomItem(item, 1));
-        } else {
-            Slimefun.runSync(() -> dispenser.getInventory().removeItem(item), 2L);
-        }
     }
 }


### PR DESCRIPTION
方块放置机在放置方块的一瞬间，玩家的取出其中物品，可以复制物品(一个被放置，一个被取出）
原理是取出的物品不能被正常清除，因为修复之前只会remove方块放置机里的物品
经过此修复，经测试已经修复，未修复前的bug在大量服务器存在，建议更新。此外，必须先清除物品再放置方块，否则也可以刷物品。