### PR TITLE
修复 基于AContainer的机器无视默认合成表处理速度问题

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -72,8 +72,6 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
             processing.remove(b);
             return true;
         });
-
-        registerDefaultRecipes();
     }
 
     @ParametersAreNonnullByDefault
@@ -231,6 +229,8 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
             warn("The processing speed has not been configured correctly. The Item was disabled.");
             warn("Make sure to call '" + getClass().getSimpleName() + "#setProcessingSpeed(...)' before registering!");
         }
+        
+        registerDefaultRecipes();
 
         if (getCapacity() > 0 && getEnergyConsumption() > 0 && getSpeed() > 0) {
             super.register(addon);


### PR DESCRIPTION
由于新版粘液使用了 #setProcessingSpeed() 方法设置速度，在设置之前为-1。而默认合成表注册方法在构造函数里调用，导致所有默认合成表速度均为负数。