### PR TITLE
移除 多余的默认合成表注册方法的调用

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/HeatedPressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/HeatedPressureChamber.java
@@ -70,8 +70,6 @@ public class HeatedPressureChamber extends AContainer {
                 }
             }
         };
-
-        this.registerDefaultRecipes();
     }
 
     private Comparator<Integer> compareSlots(DirtyChestMenu menu) {


### PR DESCRIPTION
在加热压力仓的构造函数里有一个不明用处的合成表注册调用。这个导致了与之前AContainer相同的问题，即在构造函数调用时速度为-1导致的合成表无视处理时间。移除这个使用已修复的AContainer即可。