### PR TITLE
***修复方式错误，参见另一个PR*** 修复 粘液书从设置界面返回时直接进入作弊模式

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
@@ -37,13 +37,13 @@ public final class SlimefunGuide {
 
     public static void openGuide(@Nonnull Player p, @Nonnull ItemStack guide) {
         if (getItem(SlimefunGuideMode.SURVIVAL_MODE).equals(guide)) {
-            openGuide(p, SlimefunGuideMode.CHEAT_MODE);
+            openGuide(p, SlimefunGuideMode.SURVIVAL_MODE);
         } else {
             /**
              * When using /sf cheat or /sf open_guide the ItemStack is null anyway,
              * so we don't even need to check here at this point.
              */
-            openGuide(p, SlimefunGuideMode.SURVIVAL_MODE);
+            openGuide(p, SlimefunGuideMode.CHEAT_MODE);
         }
     }
 


### PR DESCRIPTION
这个问题看起来是作者疏忽写反了... 但是总的来说还是很严重的问题.. 玩家可以越权进入作弊模式...