### PR TITLE
修复 粘液书从设置界面返回时直接进入作弊模式

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
@@ -36,7 +36,7 @@ public final class SlimefunGuide {
     }
 
     public static void openGuide(@Nonnull Player p, @Nonnull ItemStack guide) {
-        if (getItem(SlimefunGuideMode.SURVIVAL_MODE).equals(guide)) {
+        if (getItem(SlimefunGuideMode.CHEAT_MODE).equals(guide)) {
             openGuide(p, SlimefunGuideMode.CHEAT_MODE);
         } else {
             /**


### PR DESCRIPTION
大概是作者这里写错了... 通过设置界面的返回后可以直接进入作弊模式，导致玩家可以越权访问。新版粘液书有一个标记模式的NBT，在之前版本并没有.. 所以我上一个PR并没有解决使用老版粘液书/指令直接打开时的这个问题. (才不承认是脑抽了改错地方了呜呜..)