### PR TITLE
针对自动合成台的一些优化

### DIFF
--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/ChestInventoryParser.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/ChestInventoryParser.java
@@ -21,7 +21,7 @@ public class ChestInventoryParser implements CrafterInteractable{
 
     private final Inventory inv;
 
-    public ChestInventoryParser(Inventory inv){
+    public ChestInventoryParser(Inventory inv) {
         this.inv = inv;
     }
 
@@ -51,18 +51,20 @@ public class ChestInventoryParser implements CrafterInteractable{
         return inv.addItem(item).isEmpty();
     }
 
-    private boolean isFit(ItemStack item){
+    private boolean isFit(ItemStack item) {
         ItemStack[] contents = inv.getContents();
 
         ItemStackWrapper wrapper = new ItemStackWrapper(item);
         int amount = wrapper.getAmount();
 
-        for(ItemStack each : contents){
+        for (ItemStack each : contents) {
             int eachAmount = each.getAmount();
             int maxAmount = each.getMaxStackSize();
-            if(SlimefunUtils.isItemSimilar(each, wrapper, true, false) && eachAmount < maxAmount){
+            if (SlimefunUtils.isItemSimilar(each, wrapper, true, false) && eachAmount < maxAmount) {
                 int restAmount = maxAmount - eachAmount;
-                if(amount <= restAmount) return true;
+                if (amount <= restAmount) {
+                    return true;
+                }
                 amount -= restAmount;
             }
         }

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/ChestInventoryParser.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/ChestInventoryParser.java
@@ -1,0 +1,72 @@
+package com.xzavier0722.mc.plugin.slimefun4.autocrafter;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.autocrafters.AbstractAutoCrafter;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ *
+ * This is the implementation of {@link CrafterInteractable} with vanilla inventory.
+ *
+ * @author Xzavier0722
+ *
+ */
+public class ChestInventoryParser implements CrafterInteractable{
+
+    private final Inventory inv;
+
+    public ChestInventoryParser(Inventory inv){
+        this.inv = inv;
+    }
+
+    @Override
+    public boolean canOutput(ItemStack item) {
+        return inv.firstEmpty() > -1 || isFit(item);
+    }
+
+    @Override
+    public boolean matchRecipe(AbstractAutoCrafter crafter, Collection<Predicate<ItemStack>> recipe, Map<Integer, Integer> itemQuantities) {
+        for (Predicate<ItemStack> predicate : recipe) {
+            // Check if any Item matches the Predicate
+            if (!crafter.matchesAny(inv, itemQuantities, predicate)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public ItemStack getItem(int slot) {
+        return inv.getItem(slot);
+    }
+
+    @Override
+    public boolean addItem(ItemStack item) {
+        return inv.addItem(item).isEmpty();
+    }
+
+    private boolean isFit(ItemStack item){
+        ItemStack[] contents = inv.getContents();
+
+        ItemStackWrapper wrapper = new ItemStackWrapper(item);
+        int amount = wrapper.getAmount();
+
+        for(ItemStack each : contents){
+            int eachAmount = each.getAmount();
+            int maxAmount = each.getMaxStackSize();
+            if(SlimefunUtils.isItemSimilar(each, wrapper, true, false) && eachAmount < maxAmount){
+                int restAmount = maxAmount - eachAmount;
+                if(amount <= restAmount) return true;
+                amount -= restAmount;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractable.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractable.java
@@ -10,21 +10,41 @@ import java.util.function.Predicate;
 
 /**
  *
- * The interface that provide item interaction between inventory and crafter.
+ * The interface is for item interacting between inventory and crafter.
  *
  * @author Xzavier0722
  *
  */
 public interface CrafterInteractable {
 
+    /**
+     * Check if the item can be output to inventory.
+     * @param item: the item will check.
+     * @return true if there are enough space, else false.
+     */
     boolean canOutput(ItemStack item);
 
+    /**
+     * Check if the items in inventory match all recipe items.
+     * This usually use with #matchesAny() in {@link AbstractAutoCrafter}
+     * @param crafter: the crafter that invoked this method.
+     * @param recipe: the collection of recipe ingredients' predicate to test the item.
+     * @param itemQuantities: the item's slot and amount after consume.
+     * @return true if all matched, else false.
+     */
     boolean matchRecipe(AbstractAutoCrafter crafter, Collection<Predicate<ItemStack>> recipe, Map<Integer, Integer> itemQuantities);
 
     ItemStack getItem(int slot);
 
     boolean addItem(ItemStack item);
 
+    /**
+     * This is for updating the count of different ingredient in recipe.
+     * This will be invoked when the recipe is changed.
+     * Usually use for controlling the item insertion of cargo.
+     * @param b: block to update.
+     * @param count: amount of different item.
+     */
     default void setIngredientCount(Block b, int count){}
 
 

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractable.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractable.java
@@ -45,7 +45,7 @@ public interface CrafterInteractable {
      * @param b: block to update.
      * @param count: amount of different item.
      */
-    default void setIngredientCount(Block b, int count){}
+    default void setIngredientCount(Block b, int count) {}
 
 
 }

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractable.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractable.java
@@ -1,0 +1,31 @@
+package com.xzavier0722.mc.plugin.slimefun4.autocrafter;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.autocrafters.AbstractAutoCrafter;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ *
+ * The interface that provide item interaction between inventory and crafter.
+ *
+ * @author Xzavier0722
+ *
+ */
+public interface CrafterInteractable {
+
+    boolean canOutput(ItemStack item);
+
+    boolean matchRecipe(AbstractAutoCrafter crafter, Collection<Predicate<ItemStack>> recipe, Map<Integer, Integer> itemQuantities);
+
+    ItemStack getItem(int slot);
+
+    boolean addItem(ItemStack item);
+
+    default void setIngredientCount(Block b, int count){}
+
+
+}

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorHandler.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorHandler.java
@@ -2,6 +2,13 @@ package com.xzavier0722.mc.plugin.slimefun4.autocrafter;
 
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 
+/**
+ *
+ * This interface define how to get the implementation of {@link CrafterInteractable} from {@link BlockMenu}.
+ *
+ * @author Xzavier0722
+ *
+ */
 public interface CrafterInteractorHandler {
 
     CrafterInteractable getInteractor(BlockMenu menu);

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorHandler.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorHandler.java
@@ -1,0 +1,9 @@
+package com.xzavier0722.mc.plugin.slimefun4.autocrafter;
+
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+
+public interface CrafterInteractorHandler {
+
+    CrafterInteractable getInteractor(BlockMenu menu);
+
+}

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorManager.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorManager.java
@@ -1,0 +1,38 @@
+package com.xzavier0722.mc.plugin.slimefun4.autocrafter;
+
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import org.bukkit.block.Block;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ *
+ *
+ */
+public class CrafterInteractorManager {
+
+    private static final Map<String, CrafterInteractorHandler> handlers = new HashMap<>();
+
+    public static void register(String id, CrafterInteractorHandler handler){
+        handlers.put(id,handler);
+    }
+
+    public static CrafterInteractorHandler getHandler(String id){
+        return handlers.get(id);
+    }
+
+    public static CrafterInteractable getInteractor(Block b){
+        if(hasInterator(b)){
+            CrafterInteractorHandler handler = handlers.get(BlockStorage.getLocationInfo(b.getLocation(),"id"));
+            return handler.getInteractor(BlockStorage.getInventory(b));
+        }
+        return null;
+    }
+
+    public static boolean hasInterator(Block b){
+        return BlockStorage.hasBlockInfo(b) && handlers.containsKey(BlockStorage.getLocationInfo(b.getLocation(),"id"));
+    }
+
+}

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorManager.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorManager.java
@@ -8,13 +8,25 @@ import java.util.Map;
 
 /**
  *
+ * This manager provide accessibility to custom interactors.
  *
+ * @author Xzavier0722
+ *
+ * @see CrafterInteractable
+ * @see CrafterInteractorHandler
  *
  */
 public class CrafterInteractorManager {
 
     private static final Map<String, CrafterInteractorHandler> handlers = new HashMap<>();
 
+    /**
+     * Register the specific slimefun item as crafter interactor.
+     * @param id: the id of the slimefun item that will be registered as interactor.
+     * @param handler: way to get the {@link CrafterInteractable} implementation.
+     *
+     * @see CrafterInteractorHandler
+     */
     public static void register(String id, CrafterInteractorHandler handler){
         handlers.put(id,handler);
     }

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorManager.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterInteractorManager.java
@@ -27,23 +27,23 @@ public class CrafterInteractorManager {
      *
      * @see CrafterInteractorHandler
      */
-    public static void register(String id, CrafterInteractorHandler handler){
+    public static void register(String id, CrafterInteractorHandler handler) {
         handlers.put(id,handler);
     }
 
-    public static CrafterInteractorHandler getHandler(String id){
+    public static CrafterInteractorHandler getHandler(String id) {
         return handlers.get(id);
     }
 
-    public static CrafterInteractable getInteractor(Block b){
-        if(hasInterator(b)){
+    public static CrafterInteractable getInteractor(Block b) {
+        if (hasInterator(b)) {
             CrafterInteractorHandler handler = handlers.get(BlockStorage.getLocationInfo(b.getLocation(),"id"));
             return handler.getInteractor(BlockStorage.getInventory(b));
         }
         return null;
     }
 
-    public static boolean hasInterator(Block b){
+    public static boolean hasInterator(Block b) {
         return BlockStorage.hasBlockInfo(b) && handlers.containsKey(BlockStorage.getLocationInfo(b.getLocation(),"id"));
     }
 

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPort.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPort.java
@@ -53,7 +53,7 @@ public class CrafterSmartPort extends SlimefunItem{
 
                         @Override
                         public boolean onClick(InventoryClickEvent e, Player p, int slot, ItemStack cursor, ClickAction action) {
-                            return cursor == null || cursor.getType() == Material.AIR;
+                            return cursor == null || cursor.getType().isAir();
                         }
                     });
                 }
@@ -69,9 +69,9 @@ public class CrafterSmartPort extends SlimefunItem{
                 // Check if has inv
                 if(BlockStorage.hasInventory(b)){
                     // Resume the ingredient count
-                    String countStr = BlockStorage.getLocationInfo(b.getLocation(), "" + "ingredientCount");
+                    String countStr = BlockStorage.getLocationInfo(b.getLocation(),"ingredientCount");
                     if(countStr != null){
-                        int count = Integer.parseInt(BlockStorage.getLocationInfo(b.getLocation(), "" + "ingredientCount"));
+                        int count = Integer.parseInt(BlockStorage.getLocationInfo(b.getLocation(),"ingredientCount"));
                         menu.getItemInSlot(6).setAmount(count);
                     }
                 }

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPort.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPort.java
@@ -1,0 +1,136 @@
+package com.xzavier0722.mc.plugin.slimefun4.autocrafter;
+
+import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
+import me.mrCookieSlime.Slimefun.api.inventory.DirtyChestMenu;
+import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+public class CrafterSmartPort extends SlimefunItem{
+
+    public static final int[] INPUT_SLOTS = {0,1,2,3,4,5,9,10,11,12,13,14,18,19,20,21,22,23,27,28,29,30,31,32,36,37,38,39,40,41,45,46,47,48,49,50};
+    public static final int[] OUTPUT_SLOTS = {7,8,16,17,25,26,34,35,43,44,52,53};
+
+    public CrafterSmartPort(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, recipeType, recipe);
+
+        new BlockMenuPreset("CRAFTER_SMART_PORT", "&a合成机智能交互接口") {
+            @Override
+            public void init() {
+                addItem(6, getCountItem(),(p, slot, item, action)->false);
+                for(int i = 15; i < 54 ; i+=9){
+                    addItem(i, ChestMenuUtils.getBackground(),(p, slot, item, action)->false);
+                }
+
+                for(int slot : OUTPUT_SLOTS){
+                    addMenuClickHandler(slot, new AdvancedMenuClickHandler() {
+                        @Override
+                        public boolean onClick(Player p, int slot, ItemStack cursor, ClickAction action) {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean onClick(InventoryClickEvent e, Player p, int slot, ItemStack cursor, ClickAction action) {
+                            return cursor == null || cursor.getType() == Material.AIR;
+                        }
+                    });
+                }
+            }
+
+            @Override
+            public boolean canOpen(@Nonnull Block b, @Nonnull Player p) {
+                return p.hasPermission("slimefun.inventory.bypass") || SlimefunPlugin.getProtectionManager().hasPermission(p,b.getLocation(), ProtectableAction.INTERACT_BLOCK);
+            }
+
+            @Override
+            public void newInstance(@Nonnull BlockMenu menu, @Nonnull Block b){
+                // Check if has inv
+                if(BlockStorage.hasInventory(b)){
+                    // Resume the ingredient count
+                    String countStr = BlockStorage.getLocationInfo(b.getLocation(), "" + "ingredientCount");
+                    if(countStr != null){
+                        int count = Integer.parseInt(BlockStorage.getLocationInfo(b.getLocation(), "" + "ingredientCount"));
+                        menu.getItemInSlot(6).setAmount(count);
+                    }
+                }
+            }
+
+            @Override
+            public int[] getSlotsAccessedByItemTransport(ItemTransportFlow flow) {
+                return new int[0];
+            }
+
+            @Override
+            public int[] getSlotsAccessedByItemTransport(DirtyChestMenu menu, ItemTransportFlow flow, ItemStack item){
+                if(flow == ItemTransportFlow.WITHDRAW) return OUTPUT_SLOTS;
+
+                int itemAmount = 0;
+                ItemStackWrapper wrapper = new ItemStackWrapper(item);
+                for(int slot : INPUT_SLOTS){
+                    ItemStack itemInSlot = menu.getItemInSlot(slot);
+                    if(SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)){
+                        itemAmount += itemInSlot.getAmount();
+                    }
+                }
+
+                int amountLimit = INPUT_SLOTS.length / menu.getItemInSlot(6).getAmount() * wrapper.getMaxStackSize();
+                if(itemAmount + wrapper.getAmount() <= amountLimit) return INPUT_SLOTS;
+                return new int[0];
+            }
+        };
+
+        CrafterInteractorManager.register(getId(), CrafterSmartPortParser::new);
+    }
+
+    @Override
+    public void preRegister(){
+        addItemHandler(new BlockBreakHandler(false, true) {
+            @Override
+            public void onPlayerBreak(@Nonnull BlockBreakEvent e, @Nonnull ItemStack item, @Nonnull List<ItemStack> drops) {
+                Block b = e.getBlock();
+                BlockMenu inv = BlockStorage.getInventory(b);
+                if(inv != null){
+                    for(int slot : INPUT_SLOTS){
+                        ItemStack itemInSlot = inv.getItemInSlot(slot);
+                        if(itemInSlot != null) drops.add(itemInSlot);
+                    }
+
+                    for(int slot : OUTPUT_SLOTS){
+                        ItemStack itemInSlot = inv.getItemInSlot(slot);
+                        if(itemInSlot != null) drops.add(itemInSlot);
+                    }
+                }
+            }
+        });
+    }
+
+    private ItemStack getCountItem(){
+        ItemStack countItem = new ItemStack(Material.CLOCK);
+        ItemMeta im = countItem.getItemMeta();
+        im.setDisplayName(ChatColor.BLUE+"合成表的原料数量");
+        countItem.setItemMeta(im);
+        return countItem;
+    }
+}

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPort.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPort.java
@@ -40,11 +40,11 @@ public class CrafterSmartPort extends SlimefunItem{
             @Override
             public void init() {
                 addItem(6, getCountItem(),(p, slot, item, action)->false);
-                for(int i = 15; i < 54 ; i+=9){
+                for (int i = 15; i < 54 ; i+=9) {
                     addItem(i, ChestMenuUtils.getBackground(),(p, slot, item, action)->false);
                 }
 
-                for(int slot : OUTPUT_SLOTS){
+                for (int slot : OUTPUT_SLOTS) {
                     addMenuClickHandler(slot, new AdvancedMenuClickHandler() {
                         @Override
                         public boolean onClick(Player p, int slot, ItemStack cursor, ClickAction action) {
@@ -65,13 +65,14 @@ public class CrafterSmartPort extends SlimefunItem{
             }
 
             @Override
-            public void newInstance(@Nonnull BlockMenu menu, @Nonnull Block b){
+            public void newInstance(@Nonnull BlockMenu menu, @Nonnull Block b) {
                 // Check if has inv
-                if(BlockStorage.hasInventory(b)){
+                if (BlockStorage.hasInventory(b)) {
                     // Resume the ingredient count
                     String countStr = BlockStorage.getLocationInfo(b.getLocation(),"ingredientCount");
-                    if(countStr != null)
+                    if (countStr != null) {
                         menu.getItemInSlot(6).setAmount(Integer.parseInt(countStr));
+                    }
 
                 }
             }
@@ -82,20 +83,20 @@ public class CrafterSmartPort extends SlimefunItem{
             }
 
             @Override
-            public int[] getSlotsAccessedByItemTransport(DirtyChestMenu menu, ItemTransportFlow flow, ItemStack item){
-                if(flow == ItemTransportFlow.WITHDRAW) return OUTPUT_SLOTS;
+            public int[] getSlotsAccessedByItemTransport(DirtyChestMenu menu, ItemTransportFlow flow, ItemStack item) {
+                if (flow == ItemTransportFlow.WITHDRAW) return OUTPUT_SLOTS;
 
                 int itemAmount = 0;
                 ItemStackWrapper wrapper = new ItemStackWrapper(item);
-                for(int slot : INPUT_SLOTS){
+                for (int slot : INPUT_SLOTS) {
                     ItemStack itemInSlot = menu.getItemInSlot(slot);
-                    if(SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)){
+                    if (SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)) {
                         itemAmount += itemInSlot.getAmount();
                     }
                 }
 
                 int amountLimit = INPUT_SLOTS.length / menu.getItemInSlot(6).getAmount() * wrapper.getMaxStackSize();
-                if(itemAmount + wrapper.getAmount() <= amountLimit) return INPUT_SLOTS;
+                if (itemAmount + wrapper.getAmount() <= amountLimit) return INPUT_SLOTS;
                 return new int[0];
             }
         };
@@ -104,28 +105,28 @@ public class CrafterSmartPort extends SlimefunItem{
     }
 
     @Override
-    public void preRegister(){
+    public void preRegister() {
         addItemHandler(new BlockBreakHandler(false, true) {
             @Override
             public void onPlayerBreak(@Nonnull BlockBreakEvent e, @Nonnull ItemStack item, @Nonnull List<ItemStack> drops) {
                 Block b = e.getBlock();
                 BlockMenu inv = BlockStorage.getInventory(b);
-                if(inv != null){
-                    for(int slot : INPUT_SLOTS){
+                if (inv != null) {
+                    for (int slot : INPUT_SLOTS) {
                         ItemStack itemInSlot = inv.getItemInSlot(slot);
-                        if(itemInSlot != null) drops.add(itemInSlot);
+                        if (itemInSlot != null) drops.add(itemInSlot);
                     }
 
-                    for(int slot : OUTPUT_SLOTS){
+                    for (int slot : OUTPUT_SLOTS) {
                         ItemStack itemInSlot = inv.getItemInSlot(slot);
-                        if(itemInSlot != null) drops.add(itemInSlot);
+                        if (itemInSlot != null) drops.add(itemInSlot);
                     }
                 }
             }
         });
     }
 
-    private ItemStack getCountItem(){
+    private ItemStack getCountItem() {
         ItemStack countItem = new ItemStack(Material.CLOCK);
         ItemMeta im = countItem.getItemMeta();
         im.setDisplayName(ChatColor.BLUE+"合成表的原料数量");

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPort.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPort.java
@@ -70,10 +70,9 @@ public class CrafterSmartPort extends SlimefunItem{
                 if(BlockStorage.hasInventory(b)){
                     // Resume the ingredient count
                     String countStr = BlockStorage.getLocationInfo(b.getLocation(),"ingredientCount");
-                    if(countStr != null){
-                        int count = Integer.parseInt(BlockStorage.getLocationInfo(b.getLocation(),"ingredientCount"));
-                        menu.getItemInSlot(6).setAmount(count);
-                    }
+                    if(countStr != null)
+                        menu.getItemInSlot(6).setAmount(Integer.parseInt(countStr));
+
                 }
             }
 

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPortParser.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPortParser.java
@@ -16,7 +16,7 @@ public class CrafterSmartPortParser implements CrafterInteractable{
 
     BlockMenu inv;
 
-    public CrafterSmartPortParser(BlockMenu inv){
+    public CrafterSmartPortParser(BlockMenu inv) {
         this.inv = inv;
     }
 
@@ -25,13 +25,17 @@ public class CrafterSmartPortParser implements CrafterInteractable{
         ItemStackWrapper wrapper = new ItemStackWrapper(item);
 
         int amountLeft = wrapper.getAmount();
-        for(int slot : CrafterSmartPort.OUTPUT_SLOTS){
+        for (int slot : CrafterSmartPort.OUTPUT_SLOTS) {
             ItemStack itemInSlot = inv.getItemInSlot(slot);
-            if(itemInSlot == null) return true;
-            if(SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)){
+            if (itemInSlot == null) {
+                return true;
+            }
+            if (SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)) {
                 int slotItemAmount = itemInSlot.getAmount();
                 int maxAmount = itemInSlot.getMaxStackSize();
-                if(slotItemAmount + amountLeft <= maxAmount) return true;
+                if (slotItemAmount + amountLeft <= maxAmount) {
+                    return true;
+                }
                 amountLeft -= maxAmount - slotItemAmount;
             }
         }

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPortParser.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPortParser.java
@@ -1,0 +1,67 @@
+package com.xzavier0722.mc.plugin.slimefun4.autocrafter;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.autocrafters.AbstractAutoCrafter;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class CrafterSmartPortParser implements CrafterInteractable{
+
+    BlockMenu inv;
+
+    public CrafterSmartPortParser(BlockMenu inv){
+        this.inv = inv;
+    }
+
+    @Override
+    public boolean canOutput(ItemStack item) {
+        ItemStackWrapper wrapper = new ItemStackWrapper(item);
+
+        int amountLeft = wrapper.getAmount();
+        for(int slot : CrafterSmartPort.OUTPUT_SLOTS){
+            ItemStack itemInSlot = inv.getItemInSlot(slot);
+            if(itemInSlot == null) return true;
+            if(SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)){
+                int slotItemAmount = itemInSlot.getAmount();
+                int maxAmount = itemInSlot.getMaxStackSize();
+                if(slotItemAmount + amountLeft <= maxAmount) return true;
+                amountLeft -= maxAmount - slotItemAmount;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean matchRecipe(AbstractAutoCrafter crafter, Collection<Predicate<ItemStack>> recipe, Map<Integer, Integer> itemQuantities) {
+        for (Predicate<ItemStack> predicate : recipe) {
+            // Check if any Item matches the Predicate
+            if (!crafter.matchesAny(inv.toInventory(), itemQuantities, predicate)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public ItemStack getItem(int slot) {
+        return inv.getItemInSlot(slot);
+    }
+
+    @Override
+    public boolean addItem(ItemStack item) {
+        return inv.pushItem(item, CrafterSmartPort.OUTPUT_SLOTS) == null;
+    }
+
+    @Override
+    public void setIngredientCount(Block b, int count) {
+        BlockStorage.addBlockInfo(b.getLocation(), "ingredientCount", String.valueOf(count));
+        inv.getItemInSlot(6).setAmount(count);
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -860,6 +860,7 @@ public final class SlimefunItems {
     public static final SlimefunItemStack MAGNESIUM_SALT = new SlimefunItemStack("MAGNESIUM_SALT", Material.SUGAR, "&c镁盐", "", "&7是一种能在镁发电机中使用的特殊燃料");
     public static final SlimefunItemStack MAGNESIUM_GENERATOR = new SlimefunItemStack("MAGNESIUM_GENERATOR", HeadTexture.GENERATOR, "&c镁发电机", "", LoreBuilder.machine(MachineTier.MEDIUM, MachineType.GENERATOR), LoreBuilder.powerBuffer(128), LoreBuilder.powerPerSecond(36));
 
+    public static final SlimefunItemStack CRAFTER_SMART_PORT = new SlimefunItemStack("CRAFTER_SMART_PORT", Material.LIME_STAINED_GLASS, "&a合成机智能交互接口", "", "&5可以根据合成表材料数量分配输入数量", "&5并拥有指定输出槽");
     static {
         INFUSED_ELYTRA.addUnsafeEnchantment(Enchantment.MENDING, 1);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -133,8 +133,9 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
                 recipeCache.remove(b);
 
                 Block interactor = b.getRelative(BlockFace.DOWN);
-                if (CrafterInteractorManager.hasInterator(interactor))
+                if (CrafterInteractorManager.hasInterator(interactor)) {
                     CrafterInteractorManager.getInteractor(interactor).setIngredientCount(interactor, 1);
+                }
             }
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -31,19 +31,34 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import org.apache.commons.lang.Validate;
-import org.bukkit.*;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Skull;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.inventory.*;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -1,5 +1,8 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.autocrafters;
 
+import com.xzavier0722.mc.plugin.slimefun4.autocrafter.ChestInventoryParser;
+import com.xzavier0722.mc.plugin.slimefun4.autocrafter.CrafterInteractable;
+import com.xzavier0722.mc.plugin.slimefun4.autocrafter.CrafterInteractorManager;
 import io.github.thebusybiscuit.cscorelib2.data.PersistentDataAPI;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
@@ -7,12 +10,15 @@ import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNetComponentType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.AutoCrafterListener;
 import io.github.thebusybiscuit.slimefun4.implementation.tasks.AsyncRecipeChoiceTask;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.HeadTexture;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 import io.papermc.lib.PaperLib;
 import io.papermc.lib.features.blockstatesnapshot.BlockStateSnapshotResult;
@@ -31,17 +37,13 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Skull;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryHolder;
-import org.bukkit.inventory.ItemStack;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Predicate;
 
 /**
@@ -54,6 +56,8 @@ import java.util.function.Predicate;
  *
  */
 public abstract class AbstractAutoCrafter extends SlimefunItem implements EnergyNetComponent {
+
+    private final Map<Block, ItemStack> recipeCache;
 
     /**
      * The amount of energy consumed per crafting operation.
@@ -92,6 +96,8 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
         recipeStorageKey = new NamespacedKey(SlimefunPlugin.instance(), "recipe_key");
         recipeEnabledKey = new NamespacedKey(SlimefunPlugin.instance(), "recipe_enabled");
 
+        recipeCache = new HashMap<>();
+
         addItemHandler(new BlockTicker() {
 
             @Override
@@ -102,6 +108,18 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
             @Override
             public boolean isSynchronized() {
                 return true;
+            }
+        });
+
+        addItemHandler(new BlockBreakHandler(false, true) {
+            @Override
+            public void onPlayerBreak(BlockBreakEvent e, ItemStack item, List<ItemStack> drops) {
+                Block b = e.getBlock();
+                recipeCache.remove(b);
+
+                Block interactor = b.getRelative(BlockFace.DOWN);
+                if(CrafterInteractorManager.hasInterator(interactor))
+                    CrafterInteractorManager.getInteractor(interactor).setIngredientCount(interactor, 1);
             }
         });
     }
@@ -156,29 +174,88 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
     protected void tick(@Nonnull Block b, @Nonnull Config data) {
         AbstractRecipe recipe = getSelectedRecipe(b);
 
-        if (recipe == null || !recipe.isEnabled() || getCharge(b.getLocation(), data) < getEnergyConsumption()) {
-            // No recipe / disabled recipe / no energy, abort...
-            return;
-        }
+        // If no recipe, return
+        if (recipe == null) return;
 
         // The block below where we would expect our inventory holder.
         Block targetBlock = b.getRelative(BlockFace.DOWN);
 
-        // Make sure this is a Chest
+        // Check if special interactor used. If so, check the recipe.
+        if(CrafterInteractorManager.hasInterator(targetBlock)){
+            // Check if recipe change. If so, update the count...
+            ItemStack cachedRecipeResult = recipeCache.get(b);
+
+            if(cachedRecipeResult == null || !SlimefunUtils.isItemSimilar(recipe.getResult(), cachedRecipeResult, true, false)){
+                recipeCache.put(b, recipe.getResult());
+                CrafterInteractorManager.getInteractor(targetBlock).setIngredientCount(targetBlock, getIngredientCount(recipe));
+            }
+        }
+
+        // If recipe noe enabled or no enough charge, return
+        if(!recipe.isEnabled() || getCharge(b.getLocation(), data) < getEnergyConsumption()) return;
+
+
+        // Make sure this is interactable
         if (isValidInventory(targetBlock)) {
-            BlockState state = PaperLib.getBlockState(targetBlock, false).getState();
+            CrafterInteractable interactor = null;
 
-            if (state instanceof InventoryHolder) {
-                Inventory inv = ((InventoryHolder) state).getInventory();
+            if(CrafterInteractorManager.hasInterator(targetBlock)){
+                // Has valid interactor
+                interactor = CrafterInteractorManager.getInteractor(targetBlock);
+            }else{
+                // No custom interactor, check if the vanilla inventory
+                BlockState state = PaperLib.getBlockState(targetBlock, false).getState();
+                if (state instanceof InventoryHolder)
+                    interactor = new ChestInventoryParser(((InventoryHolder) state).getInventory());
+            }
 
-                if (craft(inv, recipe)) {
+            // While passing the #isValidInventory means that there should a valid interactor, double check it for sure.
+            if(interactor != null){
+                if (craft(interactor, recipe)) {
                     // We are done crafting!
                     Location loc = b.getLocation().add(0.5, 0.8, 0.5);
                     b.getWorld().spawnParticle(Particle.VILLAGER_HAPPY, loc, 6);
                     removeCharge(b.getLocation(), getEnergyConsumption());
                 }
             }
+        } else recipeCache.remove(b);
+
+    }
+
+    /**
+     * This method checks whether the given {@link Predicate} matches the provided {@link ItemStack}.
+     *
+     * @param item
+     *            The {@link ItemStack} to check
+     * @param predicate
+     *            The {@link Predicate}
+     *
+     * @return Whether the {@link Predicate} matches the {@link ItemStack}
+     */
+    @ParametersAreNonnullByDefault
+    protected boolean matches(ItemStack item, Predicate<ItemStack> predicate) {
+        return predicate.test(item);
+    }
+
+    @ParametersAreNonnullByDefault
+    public boolean matchesAny(Inventory inv, Map<Integer, Integer> itemQuantities, Predicate<ItemStack> predicate) {
+        ItemStack[] contents = inv.getContents();
+
+        for (int slot = 0; slot < contents.length; slot++) {
+            ItemStack item = contents[slot];
+
+            if (item != null) {
+                int amount = itemQuantities.getOrDefault(slot, item.getAmount());
+
+                if (amount > 0 && matches(item, predicate)) {
+                    // Update our local quantity map
+                    itemQuantities.put(slot, amount - 1);
+                    return true;
+                }
+            }
         }
+
+        return false;
     }
 
     /**
@@ -193,6 +270,9 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * @return Whether that {@link Block} has a valid {@link Inventory}
      */
     protected boolean isValidInventory(@Nonnull Block block) {
+
+        if(CrafterInteractorManager.hasInterator(block)) return true;
+
         Material type = block.getType();
 
         switch (type) {
@@ -349,41 +429,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
         SlimefunPlugin.getLocalization().sendMessage(p, "messages.auto-crafting.recipe-removed");
     }
 
-    /**
-     * This method checks whether the given {@link Predicate} matches the provided {@link ItemStack}.
-     *
-     * @param item
-     *            The {@link ItemStack} to check
-     * @param predicate
-     *            The {@link Predicate}
-     *
-     * @return Whether the {@link Predicate} matches the {@link ItemStack}
-     */
-    @ParametersAreNonnullByDefault
-    protected boolean matches(ItemStack item, Predicate<ItemStack> predicate) {
-        return predicate.test(item);
-    }
 
-    @ParametersAreNonnullByDefault
-    protected boolean matchesAny(Inventory inv, Map<Integer, Integer> itemQuantities, Predicate<ItemStack> predicate) {
-        ItemStack[] contents = inv.getContents();
-
-        for (int slot = 0; slot < contents.length; slot++) {
-            ItemStack item = contents[slot];
-
-            if (item != null) {
-                int amount = itemQuantities.getOrDefault(slot, item.getAmount());
-
-                if (amount > 0 && matches(item, predicate)) {
-                    // Update our local quantity map
-                    itemQuantities.put(slot, amount - 1);
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
 
     /**
      * This method performs a crafting operation.
@@ -399,7 +445,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      *
      * @return Whether this crafting operation was successful or not
      */
-    public boolean craft(@Nonnull Inventory inv, @Nonnull AbstractRecipe recipe) {
+    public boolean craft(@Nonnull CrafterInteractable inv, @Nonnull AbstractRecipe recipe) {
         Validate.notNull(inv, "The Inventory must not be null");
         Validate.notNull(recipe, "The Recipe shall not be null");
 
@@ -409,16 +455,11 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
         }
 
         // Check if we have an empty slot
-        if (inv.firstEmpty() != -1) {
+        if (inv.canOutput(recipe.getResult())) {
             Map<Integer, Integer> itemQuantities = new HashMap<>();
             List<ItemStack> leftoverItems = new ArrayList<>();
 
-            for (Predicate<ItemStack> predicate : recipe.getIngredients()) {
-                // Check if any Item matches the Predicate
-                if (!matchesAny(inv, itemQuantities, predicate)) {
-                    return false;
-                }
-            }
+            if(!inv.matchRecipe(this, recipe.getIngredients(), itemQuantities)) return false;
 
             // Remove ingredients
             for (Map.Entry<Integer, Integer> entry : itemQuantities.entrySet()) {
@@ -440,7 +481,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
                 }
             }
 
-            boolean success = inv.addItem(recipe.getResult().clone()).isEmpty();
+            boolean success = inv.addItem(recipe.getResult().clone());
 
             if (success) {
                 // Fixes #2926 - Push leftover items to the inventory.
@@ -573,5 +614,56 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
     @Override
     public final EnergyNetComponentType getEnergyComponentType() {
         return EnergyNetComponentType.CONSUMER;
+    }
+
+    private int getIngredientCount(AbstractRecipe recipe){
+
+        if(recipe instanceof SlimefunItemRecipe){
+            // Recipe is for slimefun item
+            List<ItemStackWrapper> itemInRecipe = new ArrayList<>();
+            for(ItemStack each : SlimefunItem.getByItem(recipe.getResult()).getRecipe()){
+                if(each == null) continue;
+                ItemStackWrapper wrapper = new ItemStackWrapper(each);
+                boolean found = false;
+                for(ItemStackWrapper foundItem : itemInRecipe){
+                    if(SlimefunUtils.isItemSimilar(wrapper, foundItem, true, false)){
+                        found = true;
+                        break;
+                    }
+                }
+                if(!found)
+                    itemInRecipe.add(wrapper);
+            }
+            return itemInRecipe.size();
+        }
+
+
+        //Recipe is for vanilla item
+        Recipe vanillaRecipe = ((VanillaRecipe) recipe).getRecipe();
+
+        if(vanillaRecipe instanceof ShapelessRecipe) return ((ShapelessRecipe)vanillaRecipe).getIngredientList().size();
+
+        // Not shape less recipe, do check the shape.
+        Set<ItemStack> itemInRecipe = new HashSet<>();
+        // Loop to read each recipe shape char
+        for(String row : ((ShapedRecipe)vanillaRecipe).getShape()){
+            for(char each : row.toCharArray()){
+                // Get MaterialChoice from char
+                RecipeChoice.MaterialChoice materialChoice= (RecipeChoice.MaterialChoice) ((ShapedRecipe)vanillaRecipe).getChoiceMap().get(each);
+                if(materialChoice != null){
+                    ItemStack itemInChoice = materialChoice.getItemStack();
+                    boolean found = false;
+                    for(ItemStack eachInRecipe : itemInRecipe){
+                        if(eachInRecipe.isSimilar(itemInChoice)){
+                            found = true;
+                            break;
+                        }
+                    }
+                    if(!found)
+                        itemInRecipe.add(itemInChoice);
+                }
+            }
+        }
+        return itemInRecipe.size();
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -118,7 +118,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
                 recipeCache.remove(b);
 
                 Block interactor = b.getRelative(BlockFace.DOWN);
-                if(CrafterInteractorManager.hasInterator(interactor))
+                if (CrafterInteractorManager.hasInterator(interactor))
                     CrafterInteractorManager.getInteractor(interactor).setIngredientCount(interactor, 1);
             }
         });
@@ -175,42 +175,47 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
         AbstractRecipe recipe = getSelectedRecipe(b);
 
         // If no recipe, return
-        if (recipe == null) return;
+        if (recipe == null) {
+            return;
+        }
 
         // The block below where we would expect our inventory holder.
         Block targetBlock = b.getRelative(BlockFace.DOWN);
 
         // Check if special interactor used. If so, check the recipe.
-        if(CrafterInteractorManager.hasInterator(targetBlock)){
+        if (CrafterInteractorManager.hasInterator(targetBlock)) {
             // Check if recipe change. If so, update the count...
             ItemStack cachedRecipeResult = recipeCache.get(b);
 
-            if(cachedRecipeResult == null || !SlimefunUtils.isItemSimilar(recipe.getResult(), cachedRecipeResult, true, false)){
+            if (cachedRecipeResult == null || !SlimefunUtils.isItemSimilar(recipe.getResult(), cachedRecipeResult, true, false)) {
                 recipeCache.put(b, recipe.getResult());
                 CrafterInteractorManager.getInteractor(targetBlock).setIngredientCount(targetBlock, getIngredientCount(recipe));
             }
         }
 
         // If recipe noe enabled or no enough charge, return
-        if(!recipe.isEnabled() || getCharge(b.getLocation(), data) < getEnergyConsumption()) return;
+        if (!recipe.isEnabled() || getCharge(b.getLocation(), data) < getEnergyConsumption()) {
+            return;
+        }
 
 
         // Make sure this is interactable
         if (isValidInventory(targetBlock)) {
             CrafterInteractable interactor = null;
 
-            if(CrafterInteractorManager.hasInterator(targetBlock)){
+            if (CrafterInteractorManager.hasInterator(targetBlock)) {
                 // Has valid interactor
                 interactor = CrafterInteractorManager.getInteractor(targetBlock);
             }else{
                 // No custom interactor, check if the vanilla inventory
                 BlockState state = PaperLib.getBlockState(targetBlock, false).getState();
-                if (state instanceof InventoryHolder)
+                if (state instanceof InventoryHolder) {
                     interactor = new ChestInventoryParser(((InventoryHolder) state).getInventory());
+                }
             }
 
             // While passing the #isValidInventory means that there should a valid interactor, double check it for sure.
-            if(interactor != null){
+            if (interactor != null) {
                 if (craft(interactor, recipe)) {
                     // We are done crafting!
                     Location loc = b.getLocation().add(0.5, 0.8, 0.5);
@@ -271,7 +276,9 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      */
     protected boolean isValidInventory(@Nonnull Block block) {
 
-        if(CrafterInteractorManager.hasInterator(block)) return true;
+        if (CrafterInteractorManager.hasInterator(block)) {
+            return true;
+        }
 
         Material type = block.getType();
 
@@ -459,7 +466,9 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
             Map<Integer, Integer> itemQuantities = new HashMap<>();
             List<ItemStack> leftoverItems = new ArrayList<>();
 
-            if(!inv.matchRecipe(this, recipe.getIngredients(), itemQuantities)) return false;
+            if (!inv.matchRecipe(this, recipe.getIngredients(), itemQuantities)) {
+                return false;
+            }
 
             // Remove ingredients
             for (Map.Entry<Integer, Integer> entry : itemQuantities.entrySet()) {
@@ -616,23 +625,24 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
         return EnergyNetComponentType.CONSUMER;
     }
 
-    private int getIngredientCount(AbstractRecipe recipe){
+    private int getIngredientCount(AbstractRecipe recipe) {
 
-        if(recipe instanceof SlimefunItemRecipe){
+        if (recipe instanceof SlimefunItemRecipe) {
             // Recipe is for slimefun item
             List<ItemStackWrapper> itemInRecipe = new ArrayList<>();
-            for(ItemStack each : SlimefunItem.getByItem(recipe.getResult()).getRecipe()){
-                if(each == null) continue;
+            for (ItemStack each : SlimefunItem.getByItem(recipe.getResult()).getRecipe()) {
+                if (each == null) continue;
                 ItemStackWrapper wrapper = new ItemStackWrapper(each);
                 boolean found = false;
-                for(ItemStackWrapper foundItem : itemInRecipe){
-                    if(SlimefunUtils.isItemSimilar(wrapper, foundItem, true, false)){
+                for (ItemStackWrapper foundItem : itemInRecipe) {
+                    if (SlimefunUtils.isItemSimilar(wrapper, foundItem, true, false)) {
                         found = true;
                         break;
                     }
                 }
-                if(!found)
+                if (!found) {
                     itemInRecipe.add(wrapper);
+                }
             }
             return itemInRecipe.size();
         }
@@ -641,26 +651,29 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
         //Recipe is for vanilla item
         Recipe vanillaRecipe = ((VanillaRecipe) recipe).getRecipe();
 
-        if(vanillaRecipe instanceof ShapelessRecipe) return ((ShapelessRecipe)vanillaRecipe).getIngredientList().size();
+        if (vanillaRecipe instanceof ShapelessRecipe) {
+            return ((ShapelessRecipe)vanillaRecipe).getIngredientList().size();
+        }
 
         // Not shape less recipe, do check the shape.
         Set<ItemStack> itemInRecipe = new HashSet<>();
         // Loop to read each recipe shape char
-        for(String row : ((ShapedRecipe)vanillaRecipe).getShape()){
-            for(char each : row.toCharArray()){
+        for (String row : ((ShapedRecipe)vanillaRecipe).getShape()) {
+            for (char each : row.toCharArray()) {
                 // Get MaterialChoice from char
                 RecipeChoice.MaterialChoice materialChoice= (RecipeChoice.MaterialChoice) ((ShapedRecipe)vanillaRecipe).getChoiceMap().get(each);
-                if(materialChoice != null){
+                if (materialChoice != null) {
                     ItemStack itemInChoice = materialChoice.getItemStack();
                     boolean found = false;
-                    for(ItemStack eachInRecipe : itemInRecipe){
-                        if(eachInRecipe.isSimilar(itemInChoice)){
+                    for (ItemStack eachInRecipe : itemInRecipe) {
+                        if (eachInRecipe.isSimilar(itemInChoice)) {
                             found = true;
                             break;
                         }
                     }
-                    if(!found)
+                    if (!found) {
                         itemInRecipe.add(itemInChoice);
+                    }
                 }
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaRecipe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaRecipe.java
@@ -41,6 +41,10 @@ class VanillaRecipe extends AbstractRecipe {
         this.recipe = recipe;
     }
 
+    public Recipe getRecipe(){
+        return recipe;
+    }
+
     @Nonnull
     private static Collection<Predicate<ItemStack>> getChoices(@Nonnull ShapedRecipe recipe) {
         List<Predicate<ItemStack>> choices = new ArrayList<>();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaRecipe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaRecipe.java
@@ -6,8 +6,12 @@ import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Keyed;
-import org.bukkit.inventory.*;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.RecipeChoice.MaterialChoice;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaRecipe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaRecipe.java
@@ -41,7 +41,7 @@ class VanillaRecipe extends AbstractRecipe {
         this.recipe = recipe;
     }
 
-    public Recipe getRecipe(){
+    public Recipe getRecipe() {
         return recipe;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.setup;
 
+import com.xzavier0722.mc.plugin.slimefun4.autocrafter.CrafterSmartPort;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
@@ -2485,6 +2486,11 @@ public final class SlimefunItemSetup {
                 .setEnergyConsumption(32)
                 .register(plugin);
 
+        new CrafterSmartPort(categories.cargo, SlimefunItems.CRAFTER_SMART_PORT, RecipeType.ENHANCED_CRAFTING_TABLE,
+                new ItemStack[]{
+                        null, SlimefunItems.CARGO_MOTOR, null,
+                        new ItemStack(Material.CHEST), SlimefunItems.CRAFTING_MOTOR, new ItemStack(Material.CHEST),
+                        null, SlimefunItems.ELECTRIC_MOTOR, null}).register(plugin);
         // @formatter:on
     }
 


### PR DESCRIPTION
1. 为自动合成台注入适用于BlockMenu的API。
2. 修复满箱状态合成台不工作问题。
3. 添加合成台智能交互接口：
- 添加专用输出槽位。
- 根据合成表原料种类数量对货运单种物品输入进行控制。这个可以防止某一种物品充满全部输入槽导致堵死。
- 注：仅对输入物品数量控制，并不会检测输入的物品。所以货运白名单还是需要的。