### PR TITLE
修复 玩家可以通过设置界面越权访问作弊菜单

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunGuideListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunGuideListener.java
@@ -53,12 +53,17 @@ public class SlimefunGuideListener implements Listener {
                 openGuide(p, e, SlimefunGuideMode.SURVIVAL_MODE);
             }
         } else if (tryOpenGuide(p, e, SlimefunGuideMode.CHEAT_MODE) == Result.ALLOW) {
+            // Permission check to prevent player from accessing the cheat menu through setting page.
+            if(!p.hasPermission("slimefun.cheat.items")) {
+                SlimefunPlugin.getLocalization().sendMessage(p, "messages.no-permission", true);
+                return;
+            }
+
             if (p.isSneaking()) {
                 SlimefunGuideSettings.openSettings(p, e.getItem());
             } else {
-                // We rather just run the command here,
-                // all necessary permission checks will be handled there.
-                p.chat("/sf cheat");
+                // Since the permission checked, directly open the cheat menu.
+                openGuide(p, e, SlimefunGuideMode.CHEAT_MODE);
             }
         }
     }


### PR DESCRIPTION
由于设置界面可以直接返回到交互时所使用的粘液指南主界面，但粘液指南打开设置菜单的交互(潜行+右键)并没有做权限检查。导致玩家可以通过作弊书的设置界面返回到作弊模式的主菜单。