### PR TITLE
修复古代基座无法右键放置物品的问题

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -91,7 +91,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> {
     public @Nonnull Optional<Item> getPlacedItem(@Nonnull Block pedestal) {
         Optional<Item> cache = pedestalItemCache.get(new BlockPosition(pedestal));
 
-        if (cache.isPresent()) {
+        if (cache != null && cache.isPresent()) {
             return cache;
         }
 


### PR DESCRIPTION
## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->
添加了对`Map#get`的null检测

## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
Fixes #386