### PR TITLE
修正：修复了自动附魔机在服务器重启或附魔过程中附魔机被敲掉后，正在附魔的装备丢失的问题

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -128,10 +128,6 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
                 return null;
             }
 
-            for (int inputSlot : getInputSlots()) {
-                menu.consumeItem(inputSlot);
-            }
-
             return recipe;
         } else {
             return null;


### PR DESCRIPTION
## 简介
修复了自动附魔机在服务器重启或附魔过程中附魔机被敲掉后，正在附魔的装备丢失的问题（吞装备）
理论上该问题不仅存在于自动附魔机和祛魔机中，所有继承自AContainer的机器都可能存在重启吞物品的问题，只是自动附魔机处理过程较长，且处理物品较为贵重（玩家装备），此问题后果较为严重和明显

## 相关的 Issues (没有可不填)
未提交issues

## 影响范围
仅对自动附魔机进行了修改，尚未对其他机器做出修改。类似issue曾在Sf官方repo中提交过，作者表示此行为正常，遂作罢……
希望相关维护人员能够权衡

## 说明
原有的自动附魔机的机制如下：
1. 附魔机左侧被消耗的物品将在附魔开始时立刻被扣除
2. 随后附魔进度开始
3. 进度结束后右侧输出附魔产物

### 问题原因
在此过程中，一旦附魔机被玩家敲掉拿下，或者服务器重启，该附魔进度和配方（recipe）将会在内存中丢失，随之丢失的还有即将输出的附魔产物

### 解决方法
不在附魔机刚开始工作的时候就扣除物品，而是在附魔结束时的tick扣除物品并输出产品，可保证此问题不再发生
修改原有附魔机流程如下
1. 附魔机开始附魔时不扣除左侧物品
2. 附魔进度开始
3. 附魔进度结束后，扣除左侧的消耗物品，同时输出附魔产物
如果左侧物品在附魔进度开始后被拿走或修改，附魔进度将会打断