### PR TITLE
补充自动合成机相关wiki链接

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -67,6 +67,8 @@ import java.util.function.Predicate;
  */
 public abstract class AbstractAutoCrafter extends SlimefunItem implements EnergyNetComponent {
 
+    private final String WIKI_PAGE = "Auto-Crafter";
+
     private final Map<Block, ItemStack> recipeCache;
 
     /**
@@ -102,6 +104,8 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
     @ParametersAreNonnullByDefault
     protected AbstractAutoCrafter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
+
+        addOfficialWikipage(WIKI_PAGE);
 
         recipeStorageKey = new NamespacedKey(Slimefun.instance(), "recipe_key");
         recipeEnabledKey = new NamespacedKey(Slimefun.instance(), "recipe_enabled");

--- a/src/main/resources/wiki.json
+++ b/src/main/resources/wiki.json
@@ -116,6 +116,8 @@
     "COPPER_INGOT" : "Copper-Ingot",
     "COPPER_WIRE" : "Copper-Wire",
     "CORINTHIAN_BRONZE_INGOT" : "Corinthian-Bronze-Ingot",
+    "CRAFTER_SMART_PORT" : "Crafter-Smart-Port",
+    "CRAFTING_MOTOR" : "Crafting-Motor",
     "CROP_GROWTH_ACCELERATOR" : "Crop-Growth-Accelerator",
     "CROP_GROWTH_ACCELERATOR_2" : "Crop-Growth-Accelerator",
     "CRUCIBLE" : "Crucible",


### PR DESCRIPTION
## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->
补充自动合成机相关wiki链接

官方wiki目前没有自动合成机的页面，所以`wiki.json`中没有链接。

## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
