### PR TITLE
更新wiki链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ Slimefun 让每个玩家可以自己决定在魔法或科技方面发展<br>
 该项目从2013年开始开发，此后一直发展.<br>
 从那时一个人开发插件到发展成一个拥有数千名参与者和一百多位贡献者的社区.<br>
 它目前添加了超过 **500 种新物品/合成配方**
-([查看关于 Slimefun 的历史](https://github.com/Slimefun/Slimefun4/wiki/Slimefun-in-a-nutshell)).
+([查看关于 Slimefun 的历史](https://slimefun.guizhanss.wiki/Slimefun-in-a-nutshell)).
 
 与此同时, Slimefun 还有种类繁多的扩展插件可供选择!<br>
-打开 [扩展列表](https://github.com/Slimefun/Slimefun4/wiki/Addons), 你可能会找到你想要的扩展.
+打开 [扩展列表](https://slimefun.guizhanss.wiki/Addons), 你可能会找到你想要的扩展.
 
 ### 导航
 * **[下载 Slimefun 4](#%e4%b8%8b%e8%bd%bd-Slimefun4)**
 * **[Discord 服务器](#discord)**
 * **[Bug 反馈](https://github.com/StarWishsama/Slimefun4/issues)**
 * **[官方Wiki](https://github.com/Slimefun/Slimefun4/wiki)**
-* **[非官方中文 Wiki](https://slimefun-wiki.guizhanss.cn/)**
-* **[FAQ](https://slimefun.guizhanss.wiki/#/FAQ)**
+* **[非官方中文 Wiki](https://slimefun.guizhanss.wiki/)**
+* **[FAQ](https://slimefun.guizhanss.wiki/FAQ)**
 
 ## :floppy_disk: 下载 Slimefun4
 (可以查看: [如何安装 Slimefun](https://slimefun.guizhanss.wiki/#/Installing-Slimefun))
@@ -99,15 +99,15 @@ Slimefun 有一个 (详细且经常维护的 - *咳咳*) Wiki 为新玩家准备
 非官方中文 Wiki: https://slimefun.guizhanss.wiki/
 
 #### :star: 有用的文章 (中文)
-* [什么是 Slimefun?](https://slimefun.guizhanss.wiki/#/Slimefun-in-a-nutshell)
-* [如何安装 Slimefun](https://slimefun.guizhanss.wiki/#/Installing-Slimefun)
-* [Slimefun 4 扩展列表](https://slimefun.guizhanss.wiki/#/wiki/Addons)
-* [Slimefun 4 扩展编写教程](https://slimefun.guizhanss.wiki/#/Developer-Guide)
-* [开始使用](https://slimefun.guizhanss.wiki/#/Getting-Started)
-* [常见问题](https://slimefun.guizhanss.wiki/#/FAQ)
-* [使用中的常见问题](https://slimefun.guizhanss.wiki/#/Common-Issues)
-* [帮助我们扩展 Wiki!](https://slimefun.guizhanss.wiki/#/Expanding-the-Wiki)
-* [帮助我们翻译 Slimefun!](https://slimefun.guizhanss.wiki/#/Translating-Slimefun)
+* [什么是 Slimefun?](https://slimefun.guizhanss.wiki/Slimefun-in-a-nutshell)
+* [如何安装 Slimefun](https://slimefun.guizhanss.wiki/Installing-Slimefun)
+* [Slimefun 4 扩展列表](https://slimefun.guizhanss.wiki/Addons)
+* [Slimefun 4 扩展编写教程](https://slimefun.guizhanss.wiki/Developer-Guide)
+* [开始使用](https://slimefun.guizhanss.wiki/Getting-Started)
+* [常见问题](https://slimefun.guizhanss.wiki/FAQ)
+* [使用中的常见问题](https://slimefun.guizhanss.wiki/Common-Issues)
+* [帮助我们扩展 Wiki!](https://slimefun.guizhanss.wiki/Expanding-the-Wiki)
+* [帮助我们翻译 Slimefun!](https://slimefun.guizhanss.wiki/Translating-Slimefun)
 
 这个 Wiki 由 @ybw0014 进行维护, 如果你发现有文章缺失, 可以咨询他补充.
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -862,7 +862,7 @@ public class SlimefunItem implements Placeable {
         Validate.notNull(page, "Wiki page cannot be null.");
         // 转换链接
         page = page.replace("#", "?id=");
-        wikiURL = Optional.of("https://slimefun.guizhanss.wiki/#/" + page);
+        wikiURL = Optional.of("https://slimefun.guizhanss.wiki/" + page);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/PlayerLanguageOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/PlayerLanguageOption.java
@@ -89,7 +89,7 @@ class PlayerLanguageOption implements SlimefunGuideOption<String> {
                 });
             } else if (i == 7) {
                 menu.addItem(7, new CustomItemStack(SlimefunUtils.getCustomHead(HeadTexture.ADD_NEW_LANGUAGE.getTexture()), Slimefun.getLocalization().getMessage(p, "guide.languages.translations.name"), "", "&7\u21E8 &e" + Slimefun.getLocalization().getMessage(p, "guide.languages.translations.lore")), (pl, slot, item, action) -> {
-                    ChatUtils.sendURL(pl, "https://github.com/Slimefun/Slimefun4/wiki/Translating-Slimefun");
+                    ChatUtils.sendURL(pl, "https://slimefun.guizhanss.wiki/Translating-Slimefun");
                     pl.closeInventory();
                     return false;
                 });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/SlimefunGuideSettings.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/SlimefunGuideSettings.java
@@ -181,7 +181,7 @@ public final class SlimefunGuideSettings {
 
         menu.addMenuClickHandler(47, (pl, slot, item, action) -> {
             pl.closeInventory();
-            ChatUtils.sendURL(pl, "https://slimefun.guizhanss.wiki/#/Addons");
+            ChatUtils.sendURL(pl, "https://slimefun.guizhanss.wiki/Addons");
             return false;
         });
 


### PR DESCRIPTION
## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->

Wiki部署方式进行了一些小更改，现在不再需要加`#/`了。

原： `https://slimefun.guizhanss.wiki/#/Addons`   
现：`https://slimefun.guizhanss.wiki/Addons`

原链接仍会生效，不用担心原链接打不开的问题。
新链接格式是为了方便统计。

## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
