### PR TITLE
恢复指南书物品的翻译

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideMode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideMode.java
@@ -2,6 +2,8 @@ package io.github.thebusybiscuit.slimefun4.core.guide;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 
+import javax.annotation.Nonnull;
+
 /**
  * This enum holds the different designs a {@link SlimefunGuide} can have.
  * Each constant corresponds to a {@link SlimefunGuideImplementation}.
@@ -17,12 +19,27 @@ public enum SlimefunGuideMode {
     /**
      * This design is the standard layout used in survival mode.
      */
-    SURVIVAL_MODE,
+    SURVIVAL_MODE("普通模式"),
 
     /**
      * This is an admin-only design which creates a {@link SlimefunGuide} that allows
      * you to spawn in any {@link SlimefunItem}
      */
-    CHEAT_MODE;
+    CHEAT_MODE("作弊模式");
+
+    private final String displayName;
+
+    SlimefunGuideMode(@Nonnull String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * 获取指南书样式的显示名称
+     *
+     * @return 指南书样式的显示名称
+     */
+    public @Nonnull String getDisplayName() {
+        return displayName;
+    }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/GuideModeOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/GuideModeOption.java
@@ -56,7 +56,7 @@ class GuideModeOption implements SlimefunGuideOption<SlimefunGuideMode> {
             }
 
             ItemMeta meta = item.getItemMeta();
-            meta.setDisplayName(ChatColor.GRAY + "Slimefun 指南样式: " + ChatColor.YELLOW + ChatUtils.humanize(selectedMode.name()));
+            meta.setDisplayName(ChatColor.GRAY + "Slimefun 指南样式: " + ChatColor.YELLOW + selectedMode.getDisplayName());
             List<String> lore = new ArrayList<>();
             lore.add("");
             lore.add((selectedMode == SlimefunGuideMode.SURVIVAL_MODE ? ChatColor.GREEN : ChatColor.GRAY) + "普通模式");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -79,7 +79,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
     public SurvivalSlimefunGuide(boolean showVanillaRecipes, boolean showHiddenItemGroupsInSearch) {
         this.showVanillaRecipes = showVanillaRecipes;
         this.showHiddenItemGroupsInSearch = showHiddenItemGroupsInSearch;
-        item = new SlimefunGuideItem(this, "&aSlimefun Guide &7(Chest GUI)");
+        item = new SlimefunGuideItem(this, "&aSlimefun 指南 &7(箱子界面)");
     }
 
     /**


### PR DESCRIPTION
<!-- 在提交代码前, 你必须阅读 [提交规范](https://github.com/StarWishsama/Slimefun4/blob/master/CONTRIBUTING.md) -->

## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->
在最新的release与canary版本中，指南书无法打开，因为物品名变成英文无法识别。
将指南书的中文名称恢复，并添加了指南书样式的翻译。

## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
