### PR TITLE
Add SlimefunBlockDropEvent

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunBlockDropEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunBlockDropEvent.java
@@ -1,0 +1,71 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.block.BlockEvent;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * This {@link Event} is called whenever a {@link Player} breaks a Slimefun block which should drop some {@link ItemStack}.
+ *
+ * @author CarmJos
+ * @see io.github.thebusybiscuit.slimefun4.implementation.listeners.BlockListener
+ */
+public class SlimefunBlockDropEvent extends BlockEvent {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Player player;
+    private List<ItemStack> drops;
+
+    public SlimefunBlockDropEvent(Player player, Block theBlock, List<ItemStack> drops) {
+        super(theBlock);
+        this.player = player;
+        this.drops = drops;
+    }
+
+
+    /**
+     * This returns the {@link Player} that broke the block.
+     *
+     * @return The {@link Player}
+     */
+    @Nonnull
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Gets the {@link List} of {@link ItemStack}s that should be dropped.
+     *
+     * @return The {@link List} of {@link ItemStack}s
+     */
+    @Nonnull
+    public List<ItemStack> getDrops() {
+        return drops;
+    }
+
+    /**
+     * Sets the {@link List} of {@link ItemStack}s that should be dropped.
+     *
+     * @param drops The {@link List} of {@link ItemStack}s
+     */
+    public void setDrops(@Nonnull List<ItemStack> drops) {
+        Validate.notNull(drops, "The drops list should not be null!");
+        this.drops = drops;
+    }
+
+    @Nonnull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -10,6 +10,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.events.SlimefunBlockDropEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -182,7 +184,12 @@ public class BlockListener implements Listener {
                 // Disable normal block drops
                 e.setDropItems(false);
 
-                for (ItemStack drop : drops) {
+                // Call event for items dropped by the block
+                SlimefunBlockDropEvent dropEvent = new SlimefunBlockDropEvent(e.getPlayer(), e.getBlock(), drops);
+                Bukkit.getPluginManager().callEvent(dropEvent);
+
+                // Only drop event's items.
+                for (ItemStack drop : dropEvent.getDrops()) {
                     // Prevent null or air from being dropped
                     if (drop != null && drop.getType() != Material.AIR) {
                         e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
In some cases, developers want to prevent slimefun's block drops or make drops directly into some containers.

But in previous codes, this is not possible because it uses the `#dropItemNaturally(...)` method.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->

I added a event called `SlimefunBlockDropEvent` to provide a way for developers edit the drops.

I have tested the event by my own plugin.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [X] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [X] I followed the existing code standards and didn't mess up the formatting.
- [X] I did my best to add documentation to any public classes or methods I added.
- [X] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.

> 该PR已于 https://github.com/Slimefun/Slimefun4/pull/3461 经过验证，但始终未合并。
> 因子插件急于使用，故提交至本版，望合并~