### PR TITLE
Jitpack 配置

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 before_install:
- - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
   - source ./install-jdk.sh --feature 17 --license GPL

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+ - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+  - source ./install-jdk.sh --feature 17 --license GPL


### PR DESCRIPTION
<!-- 在提交代码前, 你必须阅读 [提交规范](https://github.com/StarWishsama/Slimefun4/blob/master/CONTRIBUTING.md) -->

## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->
由于 Jitpack 默认使用 Java 8 编译，未配置的情况下无法使用Jitpack作为前置仓库。详见:
https://jitpack.io/#StarWishsama/Slimefun4/ecb14c0991

添加`jitpack.yml`配置文件，让 Jitpack 使用 Java 17 编译。

该PR可添加[CI skip]标注。

## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
