### PR TITLE
Update CargoNodeListener.java

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CargoNodeListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CargoNodeListener.java
@@ -29,7 +29,7 @@ public class CargoNodeListener implements Listener {
     public void onCargoNodePlace(BlockPlaceEvent e) {
         Block b = e.getBlock();
 
-        if ((b.getY() != e.getBlockAgainst().getY() || !e.getBlockReplacedState().getType().isAir()) && isCargoNode(e.getItemInHand())) {
+        if (isCargoNode(e.getItemInHand()) && (b.getY() != e.getBlockAgainst().getY() || !e.getBlockReplacedState().getType().isAir())) {
             Slimefun.getLocalization().sendMessage(e.getPlayer(), "machines.CARGO_NODES.must-be-placed", true);
             e.setCancelled(true);
         }


### PR DESCRIPTION
<!-- 在提交代码前, 你必须阅读 [提交规范](https://github.com/StarWishsama/Slimefun4/blob/master/CONTRIBUTING.md) -->

## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->
将 isCargoNode挪到了if的前面，这样当玩家放置的方块不是货运节点时，这个if可以只判断一次，而如果把isCargoNode放在后面，则可能需要判断2次或者3次，除非玩家放置的方块与被放置方块的方块的y坐标不一致，事实上，很多情况下它们都是一致的，一个方块有6个面而另外侧边的4个面都符合这个要求，但是如果把 isCargoNode挪到了if的前面，那么将首先判断放置的是不是货运节点，该表达式必须被判断因此应该把它放到前面以提升判断速度，在一个方块放置频繁的服务器上，这么做可能会更好

## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
