### PR TITLE
fix `/sf versions` permission

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -54,7 +54,7 @@ permissions:
     default: op
   slimefun.command.versions:
     description: Allows you to do /sf versions
-    default: op
+    default: true
   slimefun.command.backpack:
     description: Allows you to do /sf backpack
     default: op


### PR DESCRIPTION
<!-- 在提交代码前, 你必须阅读 [提交规范](https://github.com/StarWishsama/Slimefun4/blob/master/CONTRIBUTING.md) -->

## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->
指令`/sf versions`
可以获取到插件信息和加载的Addons列表
[SlimefunEssentials](https://github.com/JustAHuman-xD/SlimefunEssentials) 这个客户端插件有用到

## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
