### PR TITLE
feat(storage): add `YamlHelper` for migrating old data

### DIFF
--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/controller/PlayerProfileDataController.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/controller/PlayerProfileDataController.java
@@ -12,11 +12,6 @@ import io.github.thebusybiscuit.slimefun4.api.player.PlayerBackpack;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.api.researches.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-import org.bukkit.Bukkit;
-import org.bukkit.NamespacedKey;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.inventory.ItemStack;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -27,6 +22,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.inventory.ItemStack;
 
 public class PlayerProfileDataController {
     private final BackpackCache backpackCache;
@@ -213,7 +212,7 @@ public class PlayerProfileDataController {
         readExecutor.submit(() -> invokeCallback(callback, getBackpacks(pUuid)));
     }
 
-    private PlayerProfile createProfile(OfflinePlayer p) {
+    public PlayerProfile createProfile(OfflinePlayer p) {
         checkDestroy();
         var uuid = p.getUniqueId().toString();
         var cache = profileCache.get(uuid);

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/helper/YamlHelper.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/helper/YamlHelper.java
@@ -3,12 +3,44 @@ package com.xzavier0722.mc.plugin.slimefun4.storage.helper;
 import io.github.bakedlibs.dough.config.Config;
 import io.github.thebusybiscuit.slimefun4.api.researches.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import org.bukkit.Bukkit;
 
 public class YamlHelper {
-    public static void migratePlayerProfile(@Nonnull UUID uuid) {
+    public static void migratePlayerData() {
+        var playerFolder = new File("data-storage/Slimefun/Players/");
+
+        if (!playerFolder.isDirectory()) return;
+
+        for (File file : playerFolder.listFiles()) {
+            if (file.getName().endsWith(".yml")) {
+                try {
+                    var uuid = UUID.fromString(file.getName().replace(".yml", ""));
+                    var p = Bukkit.getOfflinePlayer(uuid);
+                    if (p != null && Slimefun.getRegistry().getProfileDataController().getProfile(p) == null) {
+                        migratePlayerProfile(uuid);
+                    }
+
+                    var backupFile = new File(file.getAbsolutePath() + ".bak");
+                    backupFile.createNewFile();
+                    Files.copy(file.toPath(), backupFile.toPath());
+
+                    file.delete();
+                } catch (IllegalArgumentException ignored) {
+                    // Illegal file name
+                    return;
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private static void migratePlayerProfile(@Nonnull UUID uuid) {
         var p = Bukkit.getOfflinePlayer(uuid);
         var configFile = new Config("data-storage/Slimefun/Players/" + uuid + ".yml");
 

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/helper/YamlHelper.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/helper/YamlHelper.java
@@ -1,0 +1,49 @@
+package com.xzavier0722.mc.plugin.slimefun4.storage.helper;
+
+import io.github.bakedlibs.dough.config.Config;
+import io.github.thebusybiscuit.slimefun4.api.researches.Research;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import org.bukkit.Bukkit;
+
+public class YamlHelper {
+    public static void migratePlayerProfile(@Nonnull UUID uuid) {
+        var p = Bukkit.getOfflinePlayer(uuid);
+        var configFile = new Config("data-storage/Slimefun/Players/" + uuid + ".yml");
+
+        if (!configFile.getFile().exists()) {
+            return;
+        }
+
+        var controller = Slimefun.getRegistry().getProfileDataController();
+        var profile = controller.createProfile(p);
+
+        // Research migrate
+        for (String researchID : configFile.getKeys("researches")) {
+            var research = Research.getResearchByID(Integer.parseInt(researchID));
+
+            if (research.isEmpty()) {
+                return;
+            }
+
+            profile.setResearched(research.get(), true);
+        }
+
+        // Backpack migrate
+        for (String backpackID : configFile.getKeys("backpacks")) {
+            var size = configFile.getInt("backpacks." + backpackID + ".size");
+
+            var bp = controller.createBackpack(
+                    p,
+                    profile.nextBackpackNum(),
+                    size
+            );
+
+            for (String key : configFile.getKeys("backpacks." + backpackID + ".contents")) {
+                var item = configFile.getItem("backpacks." + backpackID + ".contents." + key);
+                bp.getInventory().setItem(Integer.parseInt(key), item);
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
@@ -9,6 +9,14 @@ import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation
 import io.github.thebusybiscuit.slimefun4.core.services.localization.Language;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.setup.ResearchSetup;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -18,15 +26,6 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import ren.natsuyuk1.slimefun4.VaultHelper;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
 
 /**
  * Represents a research, which is bound to one
@@ -333,6 +332,15 @@ public class Research implements Keyed {
         }
 
         return Optional.empty();
+    }
+
+    @Deprecated
+    public static Optional<Research> getResearchByID(@Nonnull Integer oldID) {
+        if (oldID == null) {
+            return Optional.empty();
+        }
+
+        return Slimefun.getRegistry().getResearches().parallelStream().filter(r -> r.id == oldID).findFirst();
     }
 
     @Override


### PR DESCRIPTION
迁移基于文件储存的玩家数据 `PlayerProfile` 方法