### PR TITLE
Fix #853

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -169,9 +169,9 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         Material material = block.getType();
 
         block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, material);
-        Location bloclLocation = block.getLocation();
+        Location blockLocation = block.getLocation();
 
-        Optional<SlimefunItem> optionalBlockSfItem = Optional.ofNullable(StorageCacheUtils.getSfItem(bloclLocation));
+        Optional<SlimefunItem> optionalBlockSfItem = Optional.ofNullable(StorageCacheUtils.getSfItem(blockLocation));
 
         /*
          * 修复: https://github.com/SlimefunGuguProject/Slimefun4/issues/853
@@ -186,7 +186,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
 
         if (Bukkit.getPluginManager().isPluginEnabled("ExoticGarden")
                 && block.getType().equals(Material.PLAYER_HEAD)) {
-            Location leavesLocation = bloclLocation.clone();
+            Location leavesLocation = blockLocation.clone();
             leavesLocation.setY(leavesLocation.getY() - 1);
 
             Block leaveBlock = leavesLocation.getBlock();
@@ -236,7 +236,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
                 if (!dummyEvent.isCancelled()) {
                     drops.addAll(sfItem.getDrops(player));
                     block.setType(Material.AIR);
-                    Slimefun.getDatabaseManager().getBlockDataController().removeBlock(bloclLocation);
+                    Slimefun.getDatabaseManager().getBlockDataController().removeBlock(blockLocation);
                 }
             }
         });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -17,6 +17,14 @@ import io.github.thebusybiscuit.slimefun4.core.services.sounds.SoundEffect;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
@@ -27,15 +35,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.inventory.ItemStack;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This {@link SlimefunItem} is a super class for items like the {@link ExplosivePickaxe} or {@link ExplosiveShovel}.
@@ -76,7 +75,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
 
     @ParametersAreNonnullByDefault
     private void breakBlocks(
-        BlockBreakEvent e, Player p, ItemStack item, Block b, List<Block> blocks, List<ItemStack> drops) {
+            BlockBreakEvent e, Player p, ItemStack item, Block b, List<Block> blocks, List<ItemStack> drops) {
         List<Block> blocksToDestroy = new ArrayList<>();
 
         if (callExplosionEvent.getValue()) {
@@ -115,7 +114,9 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
          * 为了修复该问题应该对该列表进行排序，确保头颅先被处理，具体为什么可以看下方 breakBlock 方法。
          */
         if (Bukkit.getPluginManager().isPluginEnabled("ExoticGarden")) {
-            blocksToDestroy.sort((block1, block2) -> Boolean.compare(block2.getType().equals(Material.PLAYER_HEAD), block1.getType().equals(Material.PLAYER_HEAD)));
+            blocksToDestroy.sort((block1, block2) -> Boolean.compare(
+                    block2.getType().equals(Material.PLAYER_HEAD),
+                    block1.getType().equals(Material.PLAYER_HEAD)));
         }
 
         if (!event.isCancelled()) {
@@ -170,8 +171,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, material);
         Location bloclLocation = block.getLocation();
 
-        Optional<SlimefunItem> optionalBlockSfItem =
-            Optional.ofNullable(StorageCacheUtils.getSfItem(bloclLocation));
+        Optional<SlimefunItem> optionalBlockSfItem = Optional.ofNullable(StorageCacheUtils.getSfItem(bloclLocation));
 
         /*
          * 修复: https://github.com/SlimefunGuguProject/Slimefun4/issues/853
@@ -184,7 +184,8 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
          */
         AtomicBoolean isUseVanillaBlockBreaking = new AtomicBoolean(true);
 
-        if (Bukkit.getPluginManager().isPluginEnabled("ExoticGarden") && block.getType().equals(Material.PLAYER_HEAD)) {
+        if (Bukkit.getPluginManager().isPluginEnabled("ExoticGarden")
+                && block.getType().equals(Material.PLAYER_HEAD)) {
             Location leavesLocation = bloclLocation.clone();
             leavesLocation.setY(leavesLocation.getY() - 1);
 
@@ -193,7 +194,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
 
             if (Tag.LEAVES.isTagged(leaveBlockType)) {
                 Optional<SlimefunItem> optionalLeavesBlockSfItem =
-                    Optional.ofNullable(StorageCacheUtils.getSfItem(leavesLocation));
+                        Optional.ofNullable(StorageCacheUtils.getSfItem(leavesLocation));
 
                 optionalBlockSfItem.ifPresent(blockSfItem -> optionalLeavesBlockSfItem.ifPresent(leavesSfItem -> {
                     Collection<ItemStack> sfItemDrops = blockSfItem.getDrops();
@@ -228,7 +229,8 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
                  * Fixes #3036 and handling in general.
                  * Call the BlockBreakHandler if the block has one to allow for proper handling.
                  */
-                sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
+                sfItem.callItemHandler(
+                        BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
 
                 // Make sure the event wasn't cancelled by the BlockBreakHandler.
                 if (!dummyEvent.isCancelled()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -17,27 +17,32 @@ import io.github.thebusybiscuit.slimefun4.core.services.sounds.SoundEffect;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.inventory.ItemStack;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * This {@link SlimefunItem} is a super class for items like the {@link ExplosivePickaxe} or {@link ExplosiveShovel}.
  *
  * @author TheBusyBiscuit
- *
  * @see ExplosivePickaxe
  * @see ExplosiveShovel
- *
  */
 public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements NotPlaceable, DamageableItem {
 
@@ -71,7 +76,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
 
     @ParametersAreNonnullByDefault
     private void breakBlocks(
-            BlockBreakEvent e, Player p, ItemStack item, Block b, List<Block> blocks, List<ItemStack> drops) {
+        BlockBreakEvent e, Player p, ItemStack item, Block b, List<Block> blocks, List<ItemStack> drops) {
         List<Block> blocksToDestroy = new ArrayList<>();
 
         if (callExplosionEvent.getValue()) {
@@ -103,6 +108,15 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
 
         ExplosiveToolBreakBlocksEvent event = new ExplosiveToolBreakBlocksEvent(p, b, blocksToDestroy, item, this);
         Bukkit.getServer().getPluginManager().callEvent(event);
+
+        /*
+         * 修复: https://github.com/SlimefunGuguProject/Slimefun4/issues/853
+         *
+         * 为了修复该问题应该对该列表进行排序，确保头颅先被处理，具体为什么可以看下方 breakBlock 方法。
+         */
+        if (Bukkit.getPluginManager().isPluginEnabled("ExoticGarden")) {
+            blocksToDestroy.sort((block1, block2) -> Boolean.compare(block2.getType().equals(Material.PLAYER_HEAD), block1.getType().equals(Material.PLAYER_HEAD)));
+        }
 
         if (!event.isCancelled()) {
             for (Block block : blocksToDestroy) {
@@ -149,38 +163,86 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
     }
 
     @ParametersAreNonnullByDefault
-    private void breakBlock(BlockBreakEvent e, Player p, ItemStack item, Block b, List<ItemStack> drops) {
-        Slimefun.getProtectionManager().logAction(p, b, Interaction.BREAK_BLOCK);
-        Material material = b.getType();
+    private void breakBlock(BlockBreakEvent event, Player player, ItemStack item, Block block, List<ItemStack> drops) {
+        Slimefun.getProtectionManager().logAction(player, block, Interaction.BREAK_BLOCK);
+        Material material = block.getType();
 
-        b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, material);
-        var loc = b.getLocation();
-        SlimefunItem sfItem = StorageCacheUtils.getSfItem(loc);
+        block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, material);
+        Location bloclLocation = block.getLocation();
 
-        if (sfItem != null && !sfItem.useVanillaBlockBreaking()) {
-            /*
-             * Fixes #2989
-             * We create a dummy here to pass onto the BlockBreakHandler.
-             * This will set the correct block context.
-             */
-            BlockBreakEvent dummyEvent = new BlockBreakEvent(b, e.getPlayer());
+        Optional<SlimefunItem> optionalBlockSfItem =
+            Optional.ofNullable(StorageCacheUtils.getSfItem(bloclLocation));
 
-            /*
-             * Fixes #3036 and handling in general.
-             * Call the BlockBreakHandler if the block has one to allow for proper handling.
-             */
-            sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
+        /*
+         * 修复: https://github.com/SlimefunGuguProject/Slimefun4/issues/853
+         *
+         * 该问题源于 ExoticGarden MagicalEssence/ExoticGardenFruit useVanillaBlockBreaking 为 true，
+         * 将调用 breakNaturally 方法而非将其作为 SlimefunItem 进行处理。
+         *
+         * 此前将 blocks 进行排序，以确保头颅为最先处理的对象，检查头颅的 Y - 1 方块是否为叶子，
+         * 若为叶子则尝试获取该处的 SlimefunItem，若能获取得到则此处应为异域花园植物，将叶子处直接设置为 AIR 并移除该处 Slimefun 方块数据。
+         */
+        AtomicBoolean isUseVanillaBlockBreaking = new AtomicBoolean(true);
 
-            // Make sure the event wasn't cancelled by the BlockBreakHandler.
-            if (!dummyEvent.isCancelled()) {
-                drops.addAll(sfItem.getDrops(p));
-                b.setType(Material.AIR);
-                Slimefun.getDatabaseManager().getBlockDataController().removeBlock(loc);
+        if (Bukkit.getPluginManager().isPluginEnabled("ExoticGarden") && block.getType().equals(Material.PLAYER_HEAD)) {
+            Location leavesLocation = bloclLocation.clone();
+            leavesLocation.setY(leavesLocation.getY() - 1);
+
+            Block leaveBlock = leavesLocation.getBlock();
+            Material leaveBlockType = leaveBlock.getType();
+
+            if (Tag.LEAVES.isTagged(leaveBlockType)) {
+                Optional<SlimefunItem> optionalLeavesBlockSfItem =
+                    Optional.ofNullable(StorageCacheUtils.getSfItem(leavesLocation));
+
+                optionalBlockSfItem.ifPresent(blockSfItem -> optionalLeavesBlockSfItem.ifPresent(leavesSfItem -> {
+                    Collection<ItemStack> sfItemDrops = blockSfItem.getDrops();
+                    Collection<ItemStack> leavesSfItemDrops = leavesSfItem.getDrops();
+
+                    if (Arrays.equals(sfItemDrops.toArray(), leavesSfItemDrops.toArray())) {
+                        leaveBlock.setType(Material.AIR);
+                        Slimefun.getDatabaseManager().getBlockDataController().removeBlock(leavesLocation);
+
+                        isUseVanillaBlockBreaking.set(false);
+                    }
+                }));
             }
-        } else {
-            b.breakNaturally(item);
         }
 
-        damageItem(p, item);
+        optionalBlockSfItem.ifPresent(sfItem -> {
+            if (isUseVanillaBlockBreaking.get()) {
+                isUseVanillaBlockBreaking.set(sfItem.useVanillaBlockBreaking());
+            }
+
+            if (isUseVanillaBlockBreaking.get()) {
+                block.breakNaturally(item);
+            } else {
+                /*
+                 * Fixes #2989
+                 * We create a dummy here to pass onto the BlockBreakHandler.
+                 * This will set the correct block context.
+                 */
+                BlockBreakEvent dummyEvent = new BlockBreakEvent(block, event.getPlayer());
+
+                /*
+                 * Fixes #3036 and handling in general.
+                 * Call the BlockBreakHandler if the block has one to allow for proper handling.
+                 */
+                sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
+
+                // Make sure the event wasn't cancelled by the BlockBreakHandler.
+                if (!dummyEvent.isCancelled()) {
+                    drops.addAll(sfItem.getDrops(player));
+                    block.setType(Material.AIR);
+                    Slimefun.getDatabaseManager().getBlockDataController().removeBlock(bloclLocation);
+                }
+            }
+        });
+
+        if (optionalBlockSfItem.isEmpty()) {
+            block.breakNaturally(item);
+        }
+
+        damageItem(player, item);
     }
 }


### PR DESCRIPTION
## 简介
修复 #853 

在 ExplosiveTool.java breakBlocks 方法中对 blocksToDestroy 进行排序，确保头颅先被处理。
该问题源于 ExoticGarden MagicalEssence/ExoticGardenFruit useVanillaBlockBreaking 为 true，将调用 breakNaturally 方法而非将其作为 SlimefunItem 进行处理。

此前将 blocks 进行排序，以确保头颅为最先处理的对象，检查头颅的 Y - 1 方块是否为叶子，若为叶子则尝试获取该处的 SlimefunItem，若能获取得到则此处应为异域花园植物，将叶子处直接设置为 AIR 并移除该处 Slimefun 方块数据。

经过测试此问题成功被修复。

## 相关的 Issues
#853 