### PR TITLE
Fix jitpack deploy

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,4 +3,5 @@ before_install:
   - sdk use java 17.0.5-zulu
 
 install:
+  - chmod 777 ./mvnw
   - ./mvnw -s .mvn/settings.xml install -DskipTests


### PR DESCRIPTION
Jitpack构建dev分支失败

[build.log](https://jitpack.io/com/github/SlimefunGuguProject/Slimefun4/dev-RC-7-g28f46d1-8065/build.log)

Running install command:
./mvnw -s .mvn/settings.xml install -DskipTests
/script/buildit.sh: line 70: ./mvnw: Permission denied

使用chmod命令解决