### PR TITLE
fix(backpack): 创建背包时只能有1个物品

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BackpackListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BackpackListener.java
@@ -160,6 +160,10 @@ public class BackpackListener implements Listener {
                     Slimefun.getLocalization().sendMessage(p, "backpack.not-original-item", true);
                     return;
                 }
+                if (item.getAmount() > 1) {
+                    Slimefun.getLocalization().sendMessage(p, "backpack.no-stack", true);
+                    return;
+                }
                 PlayerBackpack.bindItem(
                         item,
                         Slimefun.getDatabaseManager()


### PR DESCRIPTION
<!-- 在提交代码前, 你必须阅读 [提交规范](https://github.com/StarWishsama/Slimefun4/blob/master/CONTRIBUTING.md) -->

## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->
当命名后背包物品数量大于1时不再继续创建。

## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
Fixes #945 