### PR TITLE
修复1.21部分附属菜单无法显示

### DIFF
--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ChestMenu.java
@@ -131,15 +131,9 @@ public class ChestMenu extends SlimefunInventoryHolder {
         // do shallow copy due to Paper ItemStack system change
         // See also: https://github.com/PaperMC/Paper/pull/10852
         ItemStack actual = item;
-        if (item instanceof SlimefunItemStack) {
-            ItemStack clone = new ItemStack(item.getType(), item.getAmount());
-
-            if (item.hasItemMeta()) {
-                clone.setItemMeta(item.getItemMeta());
-            }
-
-            actual = clone;
-        }
+        if (item != null) {
+    		actual = new CustomItemStack(item);
+    	}
 
         setSize((int) (Math.max(getSize(), Math.ceil((slot + 1) / 9d) * 9)));
 


### PR DESCRIPTION
采用CustomItemStack修复1.21菜单物品无法显示，彻底修复在其他附属某些条件下SlimefunItemStack类型无法转换CraftItemStack问题。

<!-- 在提交代码前, 你必须阅读 [提交规范](https://github.com/SlimefunGuguProject/Slimefun4/blob/master/CONTRIBUTING.md) -->

## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->

## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
