### PR TITLE
修复sqlite下tableInformationTable没有被正确初始化

### DIFF
--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/adapter/sqlite/SqliteAdapter.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/adapter/sqlite/SqliteAdapter.java
@@ -38,6 +38,7 @@ public class SqliteAdapter extends SqlCommonAdapter<SqliteConfig> {
             case BLOCK_STORAGE -> createBlockStorageTables();
         }
 
+        tableInformationTable = SqlUtils.mapTable(DataScope.TABLE_INFORMATION);
         createTableInformationTable();
     }
 


### PR DESCRIPTION
<!-- 在提交代码前, 你必须阅读 [提交规范](https://github.com/SlimefunGuguProject/Slimefun4/blob/master/CONTRIBUTING.md) -->

## 简介
<!-- 大致解释一下这个提交更改变动了什么. -->
修复sqlite下tableInformationTable没有被正确初始化
[17:48:18 ERROR]: Error occurred while enabling Slimefun vf1d7ce2-Beta (Is it up to date?)
java.lang.IllegalStateException: An exception thrown while executing sql: INSERT INTO null (table_version) SELECT '1' WHERE NOT EXISTS (SELECT 1 FROM null)
        at Slimefun-f1d7ce2-Beta.jar/com.xzavier0722.mc.plugin.slimefun4.storage.adapter.sqlcommon.SqlCommonAdapter.executeSql(SqlCommonAdapter.java:44) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/com.xzavier0722.mc.plugin.slimefun4.storage.adapter.sqlite.SqliteAdapter.executeSql(SqliteAdapter.java:403) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/com.xzavier0722.mc.plugin.slimefun4.storage.adapter.sqlite.SqliteAdapter.createTableInformationTable(SqliteAdapter.java:396) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/com.xzavier0722.mc.plugin.slimefun4.storage.adapter.sqlite.SqliteAdapter.initStorage(SqliteAdapter.java:41) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/com.xzavier0722.mc.plugin.slimefun4.storage.controller.ADataController.init(ADataController.java:44) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/com.xzavier0722.mc.plugin.slimefun4.storage.controller.BlockDataController.init(BlockDataController.java:118) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/io.github.thebusybiscuit.slimefun4.core.config.SlimefunDatabaseManager.init(SlimefunDatabaseManager.java:61) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/io.github.thebusybiscuit.slimefun4.implementation.Slimefun.onPluginStart(Slimefun.java:342) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/io.github.thebusybiscuit.slimefun4.implementation.Slimefun.onEnable(Slimefun.java:273) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:288) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:202) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:626) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:575) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:675) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:437) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:323) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1136) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:323) ~[paper-1.20.6.jar:1.20.6-147-e41d44f]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (near "null": syntax error)
        at org.sqlite.core.DB.newSQLException(DB.java:1179) ~[sqlite-jdbc-3.45.3.0.jar:?]
        at org.sqlite.core.DB.newSQLException(DB.java:1190) ~[sqlite-jdbc-3.45.3.0.jar:?]
        at org.sqlite.core.DB.throwex(DB.java:1150) ~[sqlite-jdbc-3.45.3.0.jar:?]
        at org.sqlite.core.NativeDB.prepare_utf8(Native Method) ~[sqlite-jdbc-3.45.3.0.jar:?]
        at org.sqlite.core.NativeDB.prepare(NativeDB.java:132) ~[sqlite-jdbc-3.45.3.0.jar:?]
        at org.sqlite.core.DB.prepare(DB.java:264) ~[sqlite-jdbc-3.45.3.0.jar:?]
        at org.sqlite.jdbc3.JDBC3Statement.lambda$execute$0(JDBC3Statement.java:54) ~[sqlite-jdbc-3.45.3.0.jar:?]
        at org.sqlite.jdbc3.JDBC3Statement.withConnectionTimeout(JDBC3Statement.java:454) ~[sqlite-jdbc-3.45.3.0.jar:?]
        at org.sqlite.jdbc3.JDBC3Statement.execute(JDBC3Statement.java:43) ~[sqlite-jdbc-3.45.3.0.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/com.zaxxer.hikari.pool.ProxyStatement.execute(ProxyStatement.java:94) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/com.zaxxer.hikari.pool.HikariProxyStatement.execute(HikariProxyStatement.java) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/com.xzavier0722.mc.plugin.slimefun4.storage.adapter.sqlcommon.SqlUtils.execSql(SqlUtils.java:162) ~[Slimefun-f1d7ce2-Beta.jar:?]
        at Slimefun-f1d7ce2-Beta.jar/com.xzavier0722.mc.plugin.slimefun4.storage.adapter.sqlcommon.SqlCommonAdapter.executeSql(SqlCommonAdapter.java:42) ~[Slimefun-f1d7ce2-Beta.jar:?]
        ... 20 more
## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
