### PR TITLE
Expand menu api

### DIFF
--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ChestMenu.java
@@ -34,6 +34,7 @@ public class ChestMenu extends SlimefunInventoryHolder {
     @Getter
     private String title;
 
+    @Getter
     private List<ItemStack> items;
     /**
      * Size of chestmenu
@@ -41,6 +42,7 @@ public class ChestMenu extends SlimefunInventoryHolder {
      */
     private int size = -1;
 
+    @Getter
     private Map<Integer, MenuClickHandler> handlers;
     private MenuOpeningHandler open;
     private MenuCloseHandler close;

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
@@ -11,6 +11,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.plugin.Plugin;
 
 /**
@@ -24,6 +25,17 @@ public class MenuListener implements Listener {
 
     public MenuListener(Plugin plugin) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void onOpen(InventoryOpenEvent e) {
+        // getHolder() involves Block.getState() in BlockInventory cases
+        var holder = e.getInventory().getHolder(false);
+
+        if (holder instanceof ChestMenu menu) {
+            menu.removeViewer(e.getPlayer().getUniqueId());
+            menu.getMenuOpeningHandler().onOpen((Player) e.getPlayer());
+        }
     }
 
     @EventHandler

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
@@ -11,7 +11,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.plugin.Plugin;
 
 /**
@@ -25,17 +24,6 @@ public class MenuListener implements Listener {
 
     public MenuListener(Plugin plugin) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-    }
-
-    @EventHandler
-    public void onOpen(InventoryOpenEvent e) {
-        // getHolder() involves Block.getState() in BlockInventory cases
-        var holder = e.getInventory().getHolder(false);
-
-        if (holder instanceof ChestMenu menu) {
-            menu.removeViewer(e.getPlayer().getUniqueId());
-            menu.getMenuOpeningHandler().onOpen((Player) e.getPlayer());
-        }
     }
 
     @EventHandler

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -70,7 +70,11 @@ public class BlockMenu extends DirtyChestMenu {
         this.location = l;
         this.inventory = inv;
         for (int i = 0; i < inv.getSize(); i++) {
-            addItem(i, inv.getItem(i));
+            var item = inv.getItem(i);
+            if (item == null) {
+                continue;
+            }
+            addItem(i, item);
         }
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -69,6 +69,9 @@ public class BlockMenu extends DirtyChestMenu {
         super(preset);
         this.location = l;
         this.inventory = inv;
+        for (int i = 0; i < inv.getSize(); i++) {
+            addItem(i, inv.getItem(i));
+        }
     }
 
     public void save(Location l) {


### PR DESCRIPTION
BlockMenu<init>(BlockMenuPreset, Location, Inventory)经过查看，只有move(SlimefunBlockData, Location)在使用
经过推测，这应当是机器人在改为UniversalBlockData前使用的方法，这可以解释旧的机器人在移动后menu变为空的问题，但鉴于现在机器人已经不用这个api了，所以只是拓展一下chestmenu的api