### PR TITLE
添加虚拟物品hook api

### DIFF
--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/ChestInventoryParser.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/ChestInventoryParser.java
@@ -1,8 +1,8 @@
 package com.xzavier0722.mc.plugin.slimefun4.autocrafter;
 
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.autocrafters.AbstractAutoCrafter;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -25,7 +25,7 @@ public class ChestInventoryParser implements CrafterInteractable {
 
     @Override
     public boolean canOutput(ItemStack item) {
-        return inv.firstEmpty() > -1 || isFit(item);
+        return isFit(item);
     }
 
     @Override
@@ -49,26 +49,10 @@ public class ChestInventoryParser implements CrafterInteractable {
 
     @Override
     public boolean addItem(ItemStack item) {
-        return inv.addItem(item).isEmpty();
+        return Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.MACHINE_OUTPUT) == null;
     }
 
     private boolean isFit(ItemStack item) {
-        ItemStack[] contents = inv.getContents();
-
-        ItemStackWrapper wrapper = ItemStackWrapper.wrap(item);
-        int amount = wrapper.getAmount();
-
-        for (ItemStack each : contents) {
-            int eachAmount = each.getAmount();
-            int maxAmount = each.getMaxStackSize();
-            if (SlimefunUtils.isItemSimilar(each, wrapper, true, false) && eachAmount < maxAmount) {
-                int restAmount = maxAmount - eachAmount;
-                if (amount <= restAmount) {
-                    return true;
-                }
-                amount -= restAmount;
-            }
-        }
-        return false;
+        return Slimefun.getVirtualItemService().fits(inv, item, InventoryContext.MACHINE_OUTPUT);
     }
 }

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/ChestInventoryParser.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/ChestInventoryParser.java
@@ -49,10 +49,10 @@ public class ChestInventoryParser implements CrafterInteractable {
 
     @Override
     public boolean addItem(ItemStack item) {
-        return Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.MACHINE_OUTPUT) == null;
+        return Slimefun.getItemStackService().addItem(inv, item, InventoryContext.MACHINE_OUTPUT) == null;
     }
 
     private boolean isFit(ItemStack item) {
-        return Slimefun.getVirtualItemService().fits(inv, item, InventoryContext.MACHINE_OUTPUT);
+        return Slimefun.getItemStackService().fits(inv, item, InventoryContext.MACHINE_OUTPUT);
     }
 }

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPortParser.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPortParser.java
@@ -21,7 +21,7 @@ public class CrafterSmartPortParser implements CrafterInteractable {
 
     @Override
     public boolean canOutput(ItemStack item) {
-        return Slimefun.getVirtualItemService()
+        return Slimefun.getItemStackService()
                 .fits(inv.toInventory(), item, InventoryContext.MACHINE_OUTPUT, CrafterSmartPort.OUTPUT_SLOTS);
     }
 

--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPortParser.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/autocrafter/CrafterSmartPortParser.java
@@ -1,9 +1,9 @@
 package com.xzavier0722.mc.plugin.slimefun4.autocrafter;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.autocrafters.AbstractAutoCrafter;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -21,24 +21,8 @@ public class CrafterSmartPortParser implements CrafterInteractable {
 
     @Override
     public boolean canOutput(ItemStack item) {
-        ItemStackWrapper wrapper = ItemStackWrapper.wrap(item);
-
-        int amountLeft = wrapper.getAmount();
-        for (int slot : CrafterSmartPort.OUTPUT_SLOTS) {
-            ItemStack itemInSlot = inv.getItemInSlot(slot);
-            if (itemInSlot == null) {
-                return true;
-            }
-            if (SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)) {
-                int slotItemAmount = itemInSlot.getAmount();
-                int maxAmount = itemInSlot.getMaxStackSize();
-                if (slotItemAmount + amountLeft <= maxAmount) {
-                    return true;
-                }
-                amountLeft -= maxAmount - slotItemAmount;
-            }
-        }
-        return false;
+        return Slimefun.getVirtualItemService()
+                .fits(inv.toInventory(), item, InventoryContext.MACHINE_OUTPUT, CrafterSmartPort.OUTPUT_SLOTS);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/virtual/VirtualItemHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/virtual/VirtualItemHandler.java
@@ -1,0 +1,203 @@
+package io.github.thebusybiscuit.slimefun4.api.items.virtual;
+
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * A hook for virtual or proxy items whose behavior cannot be fully expressed by the
+ * {@link ItemStack}'s visible {@link org.bukkit.Material}.
+ *
+ * <p>Implementations are expected to keep all hot-path methods cheap. They should only inspect
+ * compact metadata that was precomputed when the virtual item was created.
+ */
+public interface VirtualItemHandler {
+
+    /**
+     * The context in which two stacks are being compared.
+     */
+    enum MatchContext {
+        GENERIC,
+        STACK_MERGE,
+        RECIPE_INPUT,
+        AUTO_CRAFTER_PREDICATE
+    }
+
+    /**
+     * The context in which a stack is inserted into an inventory.
+     */
+    enum InventoryContext {
+        MENU_FIT,
+        MENU_INSERT,
+        CARGO_INSERT,
+        VANILLA_FIT,
+        MACHINE_OUTPUT,
+        OUTPUT_CHEST
+    }
+
+    /**
+     * The context in which a stack is consumed.
+     */
+    enum ConsumeContext {
+        MENU_CONSUME,
+        VIRTUAL_CRAFTING
+    }
+
+    /**
+     * The context in which a crafting remainder is resolved.
+     */
+    enum RemainderContext {
+        AUTO_CRAFTER,
+        VIRTUAL_CRAFTING
+    }
+
+    /**
+     * A tri-state comparison result.
+     */
+    enum ComparisonResult {
+        NOT_HANDLED,
+        MATCH,
+        NO_MATCH
+    }
+
+    /**
+     * A tri-state admission result.
+     */
+    enum AdmissionResult {
+        NOT_HANDLED,
+        ALLOW,
+        DENY
+    }
+
+    /**
+     * A handled value result for operations that replace a stack.
+     *
+     * @param handled
+     *            Whether the handler processed this request
+     * @param item
+     *            The replacement item, may be null to clear the slot
+     */
+    record ItemResult(boolean handled, @Nullable ItemStack item) {
+
+        private static final ItemResult NOT_HANDLED = new ItemResult(false, null);
+
+        public static @Nonnull ItemResult notHandled() {
+            return NOT_HANDLED;
+        }
+
+        public static @Nonnull ItemResult handled(@Nullable ItemStack item) {
+            return new ItemResult(true, item);
+        }
+    }
+
+    /**
+     * This should be a very cheap check that determines whether the given stack belongs to this
+     * virtual item system.
+     *
+     * @param item
+     *            The stack to inspect
+     *
+     * @return Whether this stack should be handled by this hook
+     */
+    default boolean isVirtualItem(@Nullable ItemStack item) {
+        return false;
+    }
+
+    /**
+     * Compare two stacks in a given context.
+     *
+     * @param left
+     *            The left stack
+     * @param right
+     *            The right stack
+     * @param context
+     *            The comparison context
+     *
+     * @return The comparison result
+     */
+    default @Nonnull ComparisonResult matches(
+            @Nullable ItemStack left, @Nullable ItemStack right, @Nonnull MatchContext context) {
+        return ComparisonResult.NOT_HANDLED;
+    }
+
+    /**
+     * Compare a stack against a recipe predicate.
+     *
+     * @param item
+     *            The stack to inspect
+     * @param predicate
+     *            The target predicate
+     * @param context
+     *            The comparison context
+     *
+     * @return The comparison result
+     */
+    default @Nonnull ComparisonResult matchesPredicate(
+            @Nonnull ItemStack item, @Nonnull Predicate<ItemStack> predicate, @Nonnull MatchContext context) {
+        return ComparisonResult.NOT_HANDLED;
+    }
+
+    /**
+     * Resolve the effective max stack size for the given stack.
+     *
+     * @param item
+     *            The stack to inspect
+     * @param context
+     *            The insertion context
+     * @param defaultMaxStackSize
+     *            The original max stack size
+     *
+     * @return The effective max stack size
+     */
+    default int getMaxStackSize(@Nonnull ItemStack item, @Nonnull InventoryContext context, int defaultMaxStackSize) {
+        return defaultMaxStackSize;
+    }
+
+    /**
+     * Decide whether a virtual stack may enter an empty slot in a given context.
+     *
+     * @param item
+     *            The stack to inspect
+     * @param context
+     *            The insertion context
+     *
+     * @return The admission result
+     */
+    default @Nonnull AdmissionResult allows(@Nonnull ItemStack item, @Nonnull InventoryContext context) {
+        return AdmissionResult.NOT_HANDLED;
+    }
+
+    /**
+     * Consume an amount from a stack.
+     *
+     * @param item
+     *            The original stack
+     * @param amount
+     *            The amount to consume
+     * @param replaceConsumables
+     *            Whether consumables should be replaced
+     * @param context
+     *            The consume context
+     *
+     * @return The replacement result
+     */
+    default @Nonnull ItemResult consume(
+            @Nonnull ItemStack item, int amount, boolean replaceConsumables, @Nonnull ConsumeContext context) {
+        return ItemResult.notHandled();
+    }
+
+    /**
+     * Resolve the remainder created when a stack is consumed for a crafting operation.
+     *
+     * @param item
+     *            The consumed stack
+     * @param context
+     *            The crafting context
+     *
+     * @return The remainder result
+     */
+    default @Nonnull ItemResult getRemainder(@Nonnull ItemStack item, @Nonnull RemainderContext context) {
+        return ItemResult.notHandled();
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/virtual/VirtualItemHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/virtual/VirtualItemHandler.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.api.items.virtual;
 
+import io.github.thebusybiscuit.slimefun4.api.items.ItemHandler;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -11,8 +12,17 @@ import org.bukkit.inventory.ItemStack;
  *
  * <p>Implementations are expected to keep all hot-path methods cheap. They should only inspect
  * compact metadata that was precomputed when the virtual item was created.
+ *
+ * <p>Register this handler on a {@link io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem}
+ * via {@link io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem#addItemHandler(ItemHandler...)}.
  */
-public interface VirtualItemHandler {
+public interface VirtualItemHandler extends ItemHandler {
+
+    @Override
+    @Nonnull
+    default Class<? extends ItemHandler> getIdentifier() {
+        return VirtualItemHandler.class;
+    }
 
     /**
      * The context in which two stacks are being compared.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -204,7 +204,9 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
         Inventory outputInv = findOutputInventory(outputItem, block, blockInv);
 
         if (outputInv != null) {
-            Slimefun.getVirtualItemService().addItem(outputInv, outputItem, InventoryContext.MACHINE_OUTPUT);
+            InventoryContext context =
+                    (outputInv == blockInv) ? InventoryContext.MACHINE_OUTPUT : InventoryContext.OUTPUT_CHEST;
+            Slimefun.getVirtualItemService().addItem(outputInv, outputItem, context);
         } else {
             ItemStack rest =
                     Slimefun.getVirtualItemService().addItem(blockInv, outputItem, InventoryContext.MACHINE_OUTPUT);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -181,7 +181,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
          * only refactored.
          */
         if (!outputChest.isPresent()
-                && Slimefun.getVirtualItemService().fits(placeCheckerInv, product, InventoryContext.MACHINE_OUTPUT)) {
+                && Slimefun.getItemStackService().fits(placeCheckerInv, product, InventoryContext.MACHINE_OUTPUT)) {
             return dispInv;
         } else {
             return outputChest.orElse(null);
@@ -206,10 +206,10 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
         if (outputInv != null) {
             InventoryContext context =
                     (outputInv == blockInv) ? InventoryContext.MACHINE_OUTPUT : InventoryContext.OUTPUT_CHEST;
-            Slimefun.getVirtualItemService().addItem(outputInv, outputItem, context);
+            Slimefun.getItemStackService().addItem(outputInv, outputItem, context);
         } else {
             ItemStack rest =
-                    Slimefun.getVirtualItemService().addItem(blockInv, outputItem, InventoryContext.MACHINE_OUTPUT);
+                    Slimefun.getItemStackService().addItem(blockInv, outputItem, InventoryContext.MACHINE_OUTPUT);
 
             // fallback: drop item
             if (rest != null) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -1,13 +1,13 @@
 package io.github.thebusybiscuit.slimefun4.core.multiblocks;
 
 import com.google.common.base.Preconditions;
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSpawnReason;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
@@ -180,7 +180,8 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
          * It's functionally the same as the old fit check for the dispenser,
          * only refactored.
          */
-        if (!outputChest.isPresent() && InvUtils.fits(placeCheckerInv, product)) {
+        if (!outputChest.isPresent()
+                && Slimefun.getVirtualItemService().fits(placeCheckerInv, product, InventoryContext.MACHINE_OUTPUT)) {
             return dispInv;
         } else {
             return outputChest.orElse(null);
@@ -203,9 +204,10 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
         Inventory outputInv = findOutputInventory(outputItem, block, blockInv);
 
         if (outputInv != null) {
-            outputInv.addItem(outputItem);
+            Slimefun.getVirtualItemService().addItem(outputInv, outputItem, InventoryContext.MACHINE_OUTPUT);
         } else {
-            ItemStack rest = blockInv.addItem(outputItem).get(0);
+            ItemStack rest =
+                    Slimefun.getVirtualItemService().addItem(blockInv, outputItem, InventoryContext.MACHINE_OUTPUT);
 
             // fallback: drop item
             if (rest != null) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
@@ -119,23 +119,22 @@ class CargoNetworkTask implements Runnable {
         Inventory inv = inventories.get(inputTarget.getLocation());
 
         if (inv != null) {
+            ItemStack rest;
+
             // Check if the original slot hasn't been occupied in the meantime
             if (inv.getItem(previousSlot) == null) {
-                ItemStack rest = Slimefun.getVirtualItemService()
-                        .addItem(inv, item, InventoryContext.CARGO_INSERT, previousSlot);
-                if (rest != null && !manager.isItemDeletionEnabled()) {
-                    SlimefunUtils.spawnItem(
-                            inputTarget.getLocation().add(0, 1, 0), rest, ItemSpawnReason.CARGO_OVERFLOW);
+                rest = Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.CARGO_INSERT, previousSlot);
+                if (rest != null) {
+                    rest = Slimefun.getVirtualItemService().addItem(inv, rest, InventoryContext.CARGO_INSERT);
                 }
             } else {
                 // Try to add the item into another available slot then
-                ItemStack rest = Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.CARGO_INSERT);
+                rest = Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.CARGO_INSERT);
+            }
 
-                if (rest != null && !manager.isItemDeletionEnabled()) {
-                    // If the item still couldn't be inserted, simply drop it on the ground
-                    SlimefunUtils.spawnItem(
-                            inputTarget.getLocation().add(0, 1, 0), rest, ItemSpawnReason.CARGO_OVERFLOW);
-                }
+            if (rest != null && !manager.isItemDeletionEnabled()) {
+                // If the item still couldn't be inserted, simply drop it on the ground
+                SlimefunUtils.spawnItem(inputTarget.getLocation().add(0, 1, 0), rest, ItemSpawnReason.CARGO_OVERFLOW);
             }
         } else {
             DirtyChestMenu menu = CargoUtils.getChestMenu(inputTarget);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
@@ -123,13 +123,13 @@ class CargoNetworkTask implements Runnable {
 
             // Check if the original slot hasn't been occupied in the meantime
             if (inv.getItem(previousSlot) == null) {
-                rest = Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.CARGO_INSERT, previousSlot);
+                rest = Slimefun.getItemStackService().addItem(inv, item, InventoryContext.CARGO_INSERT, previousSlot);
                 if (rest != null) {
-                    rest = Slimefun.getVirtualItemService().addItem(inv, rest, InventoryContext.CARGO_INSERT);
+                    rest = Slimefun.getItemStackService().addItem(inv, rest, InventoryContext.CARGO_INSERT);
                 }
             } else {
                 // Try to add the item into another available slot then
-                rest = Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.CARGO_INSERT);
+                rest = Slimefun.getItemStackService().addItem(inv, item, InventoryContext.CARGO_INSERT);
             }
 
             if (rest != null && !manager.isItemDeletionEnabled()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
@@ -4,6 +4,7 @@ import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.bakedlibs.dough.blocks.BlockPosition;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSpawnReason;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.core.networks.NetworkManager;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
@@ -120,10 +121,15 @@ class CargoNetworkTask implements Runnable {
         if (inv != null) {
             // Check if the original slot hasn't been occupied in the meantime
             if (inv.getItem(previousSlot) == null) {
-                inv.setItem(previousSlot, item);
+                ItemStack rest = Slimefun.getVirtualItemService()
+                        .addItem(inv, item, InventoryContext.CARGO_INSERT, previousSlot);
+                if (rest != null && !manager.isItemDeletionEnabled()) {
+                    SlimefunUtils.spawnItem(
+                            inputTarget.getLocation().add(0, 1, 0), rest, ItemSpawnReason.CARGO_OVERFLOW);
+                }
             } else {
                 // Try to add the item into another available slot then
-                ItemStack rest = inv.addItem(item).get(0);
+                ItemStack rest = Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.CARGO_INSERT);
 
                 if (rest != null && !manager.isItemDeletionEnabled()) {
                     // If the item still couldn't be inserted, simply drop it on the ground

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
@@ -4,6 +4,9 @@ import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import com.xzavier0722.mc.plugin.slimefuncomplib.event.cargo.CargoInsertEvent;
 import com.xzavier0722.mc.plugin.slimefuncomplib.event.cargo.CargoWithdrawEvent;
 import io.github.bakedlibs.dough.inventory.InvUtils;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ComparisonResult;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.MatchContext;
 import io.github.thebusybiscuit.slimefun4.core.debug.Debug;
 import io.github.thebusybiscuit.slimefun4.core.debug.TestCase;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -309,12 +312,34 @@ final class CargoUtils {
         for (int slot : menu.getPreset().getSlotsAccessedByItemTransport(menu, ItemTransportFlow.INSERT, wrapper)) {
             ItemStack itemInSlot = menu.getItemInSlot(slot);
 
-            if (itemInSlot == null) {
+            if (itemInSlot == null || itemInSlot.getType().isAir()) {
+                if (!Slimefun.getVirtualItemService().canInsertIntoEmptySlot(stack, InventoryContext.CARGO_INSERT)) {
+                    continue;
+                }
+
+                int maxStackSize = Math.min(
+                        Slimefun.getVirtualItemService()
+                                .getMaxStackSize(stack, InventoryContext.CARGO_INSERT, stack.getMaxStackSize()),
+                        menu.toInventory().getMaxStackSize());
+                if (stack.getAmount() > maxStackSize) {
+                    ItemStack inserted = stack.clone();
+                    inserted.setAmount(maxStackSize);
+                    menu.replaceExistingItem(slot, inserted);
+                    stack.setAmount(stack.getAmount() - maxStackSize);
+                    return stack;
+                }
+
                 menu.replaceExistingItem(slot, stack);
                 return null;
             }
 
-            int maxStackSize = itemInSlot.getType().getMaxStackSize();
+            int maxStackSize = Math.min(
+                    Slimefun.getVirtualItemService()
+                            .getMaxStackSize(
+                                    itemInSlot,
+                                    InventoryContext.CARGO_INSERT,
+                                    itemInSlot.getType().getMaxStackSize()),
+                    menu.toInventory().getMaxStackSize());
             int currentAmount = itemInSlot.getAmount();
 
             if (!smartFill && currentAmount == maxStackSize) {
@@ -322,7 +347,14 @@ final class CargoUtils {
                 continue;
             }
 
-            if (SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)) {
+            ComparisonResult comparison =
+                    Slimefun.getVirtualItemService().matches(itemInSlot, stack, MatchContext.STACK_MERGE);
+            if (comparison == ComparisonResult.NO_MATCH) {
+                continue;
+            }
+
+            if ((comparison == ComparisonResult.MATCH)
+                    || SlimefunUtils.isItemSimilarWithoutVirtualItems(itemInSlot, wrapper, true, false)) {
                 if (currentAmount < maxStackSize) {
                     int amount = currentAmount + stack.getAmount();
 
@@ -363,19 +395,48 @@ final class CargoUtils {
             // Changes to this ItemStack are synchronized with the Item in the Inventory
             ItemStack itemInSlot = contents[slot];
 
-            if (itemInSlot == null) {
+            if (itemInSlot == null || itemInSlot.getType().isAir()) {
+                if (!Slimefun.getVirtualItemService().canInsertIntoEmptySlot(stack, InventoryContext.CARGO_INSERT)) {
+                    continue;
+                }
+
+                int maxStackSize = Math.min(
+                        Slimefun.getVirtualItemService()
+                                .getMaxStackSize(stack, InventoryContext.CARGO_INSERT, stack.getMaxStackSize()),
+                        inv.getMaxStackSize());
+                if (stack.getAmount() > maxStackSize) {
+                    ItemStack inserted = stack.clone();
+                    inserted.setAmount(maxStackSize);
+                    inv.setItem(slot, inserted);
+                    stack.setAmount(stack.getAmount() - maxStackSize);
+                    return stack;
+                }
+
                 inv.setItem(slot, stack);
                 return null;
             } else {
                 int currentAmount = itemInSlot.getAmount();
-                int maxStackSize = itemInSlot.getType().getMaxStackSize();
+                int maxStackSize = Math.min(
+                        Slimefun.getVirtualItemService()
+                                .getMaxStackSize(
+                                        itemInSlot,
+                                        InventoryContext.CARGO_INSERT,
+                                        itemInSlot.getType().getMaxStackSize()),
+                        inv.getMaxStackSize());
 
                 if (!smartFill && currentAmount == maxStackSize) {
                     // Skip full stacks - Performance optimization for non-smartfill nodes
                     continue;
                 }
 
-                if (SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false)) {
+                ComparisonResult comparison =
+                        Slimefun.getVirtualItemService().matches(itemInSlot, stack, MatchContext.STACK_MERGE);
+                if (comparison == ComparisonResult.NO_MATCH) {
+                    continue;
+                }
+
+                if ((comparison == ComparisonResult.MATCH)
+                        || SlimefunUtils.isItemSimilarWithoutVirtualItems(itemInSlot, wrapper, true, false)) {
                     if (currentAmount < maxStackSize) {
                         int amount = currentAmount + stack.getAmount();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
@@ -313,12 +313,12 @@ final class CargoUtils {
             ItemStack itemInSlot = menu.getItemInSlot(slot);
 
             if (itemInSlot == null || itemInSlot.getType().isAir()) {
-                if (!Slimefun.getVirtualItemService().canInsertIntoEmptySlot(stack, InventoryContext.CARGO_INSERT)) {
+                if (!Slimefun.getItemStackService().canInsertIntoEmptySlot(stack, InventoryContext.CARGO_INSERT)) {
                     continue;
                 }
 
                 int maxStackSize = Math.min(
-                        Slimefun.getVirtualItemService()
+                        Slimefun.getItemStackService()
                                 .getMaxStackSize(stack, InventoryContext.CARGO_INSERT, stack.getMaxStackSize()),
                         menu.toInventory().getMaxStackSize());
                 if (stack.getAmount() > maxStackSize) {
@@ -334,7 +334,7 @@ final class CargoUtils {
             }
 
             int maxStackSize = Math.min(
-                    Slimefun.getVirtualItemService()
+                    Slimefun.getItemStackService()
                             .getMaxStackSize(
                                     itemInSlot,
                                     InventoryContext.CARGO_INSERT,
@@ -348,7 +348,7 @@ final class CargoUtils {
             }
 
             ComparisonResult comparison =
-                    Slimefun.getVirtualItemService().matches(itemInSlot, stack, MatchContext.STACK_MERGE);
+                    Slimefun.getItemStackService().matches(itemInSlot, stack, MatchContext.STACK_MERGE);
             if (comparison == ComparisonResult.NO_MATCH) {
                 continue;
             }
@@ -396,12 +396,12 @@ final class CargoUtils {
             ItemStack itemInSlot = contents[slot];
 
             if (itemInSlot == null || itemInSlot.getType().isAir()) {
-                if (!Slimefun.getVirtualItemService().canInsertIntoEmptySlot(stack, InventoryContext.CARGO_INSERT)) {
+                if (!Slimefun.getItemStackService().canInsertIntoEmptySlot(stack, InventoryContext.CARGO_INSERT)) {
                     continue;
                 }
 
                 int maxStackSize = Math.min(
-                        Slimefun.getVirtualItemService()
+                        Slimefun.getItemStackService()
                                 .getMaxStackSize(stack, InventoryContext.CARGO_INSERT, stack.getMaxStackSize()),
                         inv.getMaxStackSize());
                 if (stack.getAmount() > maxStackSize) {
@@ -417,7 +417,7 @@ final class CargoUtils {
             } else {
                 int currentAmount = itemInSlot.getAmount();
                 int maxStackSize = Math.min(
-                        Slimefun.getVirtualItemService()
+                        Slimefun.getItemStackService()
                                 .getMaxStackSize(
                                         itemInSlot,
                                         InventoryContext.CARGO_INSERT,
@@ -430,7 +430,7 @@ final class CargoUtils {
                 }
 
                 ComparisonResult comparison =
-                        Slimefun.getVirtualItemService().matches(itemInSlot, stack, MatchContext.STACK_MERGE);
+                        Slimefun.getItemStackService().matches(itemInSlot, stack, MatchContext.STACK_MERGE);
                 if (comparison == ComparisonResult.NO_MATCH) {
                     continue;
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/ItemStackService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/ItemStackService.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang.Validate;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-public final class VirtualItemService {
+public final class ItemStackService {
 
     public boolean isVirtualItem(@Nullable ItemStack item) {
         return resolveHandler(item) != null;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
@@ -196,11 +196,62 @@ public final class VirtualItemService {
             return leftovers.values().iterator().next();
         }
 
+        if (!isVirtualItem(item) && slots.length > 0) {
+            return addItemDirectly(inventory, item, context, slots);
+        }
+
         ItemStack[] contents = Arrays.stream(inventory.getContents())
                 .map(stack -> stack == null ? null : stack.clone())
                 .toArray(ItemStack[]::new);
         int amountLeft = insertIntoSnapshot(contents, inventory.getMaxStackSize(), item, context, slots);
         inventory.setContents(contents);
+
+        if (amountLeft <= 0) {
+            return null;
+        }
+
+        ItemStack remainder = item.clone();
+        remainder.setAmount(amountLeft);
+        return remainder;
+    }
+
+    private @Nullable ItemStack addItemDirectly(
+            @Nonnull Inventory inventory, @Nonnull ItemStack item, @Nonnull InventoryContext context, int... slots) {
+        int amountLeft = item.getAmount();
+        int inventoryMaxStackSize = inventory.getMaxStackSize();
+
+        for (int slot : slots) {
+            if (slot < 0 || slot >= inventory.getSize()) {
+                continue;
+            }
+
+            ItemStack itemInSlot = inventory.getItem(slot);
+
+            if (itemInSlot == null || itemInSlot.getType().isAir()) {
+                int maxStackSize = Math.min(item.getMaxStackSize(), inventoryMaxStackSize);
+                int movedAmount = Math.min(amountLeft, maxStackSize);
+
+                ItemStack inserted = item.clone();
+                inserted.setAmount(movedAmount);
+                inventory.setItem(slot, inserted);
+                amountLeft -= movedAmount;
+            } else if (itemInSlot.isSimilar(item)) {
+                int maxStackSize = Math.min(itemInSlot.getMaxStackSize(), inventoryMaxStackSize);
+                int freeSpace = Math.max(0, maxStackSize - itemInSlot.getAmount());
+
+                if (freeSpace <= 0) {
+                    continue;
+                }
+
+                int movedAmount = Math.min(amountLeft, freeSpace);
+                itemInSlot.setAmount(itemInSlot.getAmount() + movedAmount);
+                amountLeft -= movedAmount;
+            }
+
+            if (amountLeft <= 0) {
+                return null;
+            }
+        }
 
         if (amountLeft <= 0) {
             return null;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
@@ -2,8 +2,7 @@ package io.github.thebusybiscuit.slimefun4.core.services;
 
 import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.bakedlibs.dough.items.ItemUtils;
-import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
-import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemHandler;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler;
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.AdmissionResult;
@@ -13,165 +12,19 @@ import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.I
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ItemResult;
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.MatchContext;
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.RemainderContext;
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import java.util.Arrays;
-import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Optional;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.Validate;
-import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataContainer;
-import org.bukkit.persistence.PersistentDataType;
 
 public final class VirtualItemService {
-
-    private static final String ADDON_OWNER_KEY = "virtual_item_owner_addon";
-    private static final String ITEM_OWNER_KEY = "virtual_item_owner_item";
-
-    private final Map<String, VirtualItemHandler> addonHandlers = new ConcurrentHashMap<>();
-    private final Map<String, VirtualItemHandler> itemHandlers = new ConcurrentHashMap<>();
-
-    private volatile @Nullable NamespacedKey addonOwnerKey;
-    private volatile @Nullable NamespacedKey itemOwnerKey;
-
-    public void registerHandler(@Nonnull SlimefunAddon addon, @Nonnull VirtualItemHandler handler) {
-        Validate.notNull(addon, "The addon cannot be null");
-        Validate.notNull(handler, "The handler cannot be null");
-        addonHandlers.put(getAddonKey(addon), handler);
-    }
-
-    public void unregisterHandler(@Nonnull SlimefunAddon addon) {
-        Validate.notNull(addon, "The addon cannot be null");
-        addonHandlers.remove(getAddonKey(addon));
-    }
-
-    public void clearHandlers(@Nonnull SlimefunAddon addon) {
-        Validate.notNull(addon, "The addon cannot be null");
-
-        String addonKey = getAddonKey(addon);
-        addonHandlers.remove(addonKey);
-
-        for (String itemId : itemHandlers.keySet()) {
-            if (addonOwnsItem(addonKey, itemId)) {
-                itemHandlers.remove(itemId);
-            }
-        }
-    }
-
-    public @Nullable VirtualItemHandler getHandler(@Nonnull SlimefunAddon addon) {
-        Validate.notNull(addon, "The addon cannot be null");
-        return addonHandlers.get(getAddonKey(addon));
-    }
-
-    public boolean hasHandler(@Nonnull SlimefunAddon addon) {
-        return getHandler(addon) != null;
-    }
-
-    public void registerHandler(@Nonnull SlimefunItem item, @Nonnull VirtualItemHandler handler) {
-        Validate.notNull(item, "The SlimefunItem cannot be null");
-        Validate.notNull(handler, "The handler cannot be null");
-        Validate.isTrue(
-                item.getState() != ItemState.UNREGISTERED,
-                "The SlimefunItem must be registered before assigning a virtual item handler");
-
-        itemHandlers.put(item.getId(), handler);
-    }
-
-    public void unregisterHandler(@Nonnull SlimefunItem item) {
-        Validate.notNull(item, "The SlimefunItem cannot be null");
-        itemHandlers.remove(item.getId());
-    }
-
-    public @Nullable VirtualItemHandler getHandler(@Nonnull SlimefunItem item) {
-        Validate.notNull(item, "The SlimefunItem cannot be null");
-
-        VirtualItemHandler itemHandler = itemHandlers.get(item.getId());
-        if (itemHandler != null) {
-            return itemHandler;
-        }
-
-        if (item.getState() == ItemState.UNREGISTERED) {
-            return null;
-        }
-
-        return addonHandlers.get(getAddonKey(item.getAddon()));
-    }
-
-    public boolean hasHandler(@Nonnull SlimefunItem item) {
-        return getHandler(item) != null;
-    }
-
-    public boolean hasHandler() {
-        return !addonHandlers.isEmpty() || !itemHandlers.isEmpty();
-    }
-
-    public void setOwner(@Nonnull ItemStack item, @Nonnull SlimefunAddon addon) {
-        Validate.notNull(item, "The item cannot be null");
-        Validate.notNull(addon, "The addon cannot be null");
-
-        ItemMeta meta = item.getItemMeta();
-        Validate.notNull(meta, "The item meta cannot be null");
-        setOwner(meta, addon);
-        item.setItemMeta(meta);
-    }
-
-    public void setOwner(@Nonnull ItemMeta meta, @Nonnull SlimefunAddon addon) {
-        Validate.notNull(meta, "The item meta cannot be null");
-        Validate.notNull(addon, "The addon cannot be null");
-
-        PersistentDataContainer container = meta.getPersistentDataContainer();
-        container.remove(getItemOwnerKey());
-        container.set(getAddonOwnerKey(), PersistentDataType.STRING, getAddonKey(addon));
-    }
-
-    public void setOwner(@Nonnull ItemStack item, @Nonnull SlimefunItem slimefunItem) {
-        Validate.notNull(item, "The item cannot be null");
-        Validate.notNull(slimefunItem, "The SlimefunItem cannot be null");
-
-        ItemMeta meta = item.getItemMeta();
-        Validate.notNull(meta, "The item meta cannot be null");
-        setOwner(meta, slimefunItem);
-        item.setItemMeta(meta);
-    }
-
-    public void setOwner(@Nonnull ItemMeta meta, @Nonnull SlimefunItem slimefunItem) {
-        Validate.notNull(meta, "The item meta cannot be null");
-        Validate.notNull(slimefunItem, "The SlimefunItem cannot be null");
-        Validate.isTrue(
-                slimefunItem.getState() != ItemState.UNREGISTERED,
-                "The SlimefunItem must be registered before assigning it as a virtual item owner");
-
-        PersistentDataContainer container = meta.getPersistentDataContainer();
-        container.remove(getAddonOwnerKey());
-        container.set(getItemOwnerKey(), PersistentDataType.STRING, slimefunItem.getId());
-    }
-
-    public void clearOwner(@Nonnull ItemStack item) {
-        Validate.notNull(item, "The item cannot be null");
-
-        ItemMeta meta = item.getItemMeta();
-        if (meta == null) {
-            return;
-        }
-
-        clearOwner(meta);
-        item.setItemMeta(meta);
-    }
-
-    public void clearOwner(@Nonnull ItemMeta meta) {
-        Validate.notNull(meta, "The item meta cannot be null");
-        PersistentDataContainer container = meta.getPersistentDataContainer();
-        container.remove(getAddonOwnerKey());
-        container.remove(getItemOwnerKey());
-    }
 
     public boolean isVirtualItem(@Nullable ItemStack item) {
         return resolveHandler(item) != null;
@@ -179,23 +32,22 @@ public final class VirtualItemService {
 
     public @Nonnull ComparisonResult matches(
             @Nullable ItemStack left, @Nullable ItemStack right, @Nonnull MatchContext context) {
-        ResolvedHandler leftHandler = resolveHandler(left);
-        ResolvedHandler rightHandler = resolveHandler(right);
+        VirtualItemHandler leftHandler = resolveHandler(left);
+        VirtualItemHandler rightHandler = resolveHandler(right);
 
         if (leftHandler == null && rightHandler == null) {
             return ComparisonResult.NOT_HANDLED;
         }
 
         if (leftHandler != null && rightHandler != null) {
-            VirtualItemHandler sharedHandler = resolveSharedHandler(leftHandler, rightHandler);
-            if (sharedHandler == null) {
-                return ComparisonResult.NO_MATCH;
+            if (leftHandler == rightHandler) {
+                return leftHandler.matches(left, right, context);
             }
 
-            return sharedHandler.matches(left, right, context);
+            return ComparisonResult.NO_MATCH;
         }
 
-        return (leftHandler != null ? leftHandler.handler() : rightHandler.handler()).matches(left, right, context);
+        return (leftHandler != null ? leftHandler : rightHandler).matches(left, right, context);
     }
 
     public boolean isSimilar(
@@ -218,9 +70,9 @@ public final class VirtualItemService {
 
     public boolean matchesPredicate(
             @Nonnull ItemStack item, @Nonnull Predicate<ItemStack> predicate, @Nonnull MatchContext context) {
-        ResolvedHandler resolvedHandler = resolveHandler(item);
-        if (resolvedHandler != null) {
-            ComparisonResult comparison = resolvedHandler.handler().matchesPredicate(item, predicate, context);
+        VirtualItemHandler handler = resolveHandler(item);
+        if (handler != null) {
+            ComparisonResult comparison = handler.matchesPredicate(item, predicate, context);
             if (comparison == ComparisonResult.MATCH) {
                 return true;
             }
@@ -236,21 +88,21 @@ public final class VirtualItemService {
     public int getMaxStackSize(@Nonnull ItemStack item, @Nonnull InventoryContext context, int defaultMaxStackSize) {
         Validate.notNull(item, "The item cannot be null");
 
-        ResolvedHandler resolvedHandler = resolveHandler(item);
-        if (resolvedHandler == null) {
+        VirtualItemHandler handler = resolveHandler(item);
+        if (handler == null) {
             return defaultMaxStackSize;
         }
 
-        return Math.max(1, resolvedHandler.handler().getMaxStackSize(item, context, defaultMaxStackSize));
+        return Math.max(1, handler.getMaxStackSize(item, context, defaultMaxStackSize));
     }
 
     public @Nonnull AdmissionResult allows(@Nonnull ItemStack item, @Nonnull InventoryContext context) {
-        ResolvedHandler resolvedHandler = resolveHandler(item);
-        if (resolvedHandler == null) {
+        VirtualItemHandler handler = resolveHandler(item);
+        if (handler == null) {
             return AdmissionResult.NOT_HANDLED;
         }
 
-        return resolvedHandler.handler().allows(item, context);
+        return handler.allows(item, context);
     }
 
     public boolean canInsertIntoEmptySlot(@Nonnull ItemStack item, @Nonnull InventoryContext context) {
@@ -259,21 +111,21 @@ public final class VirtualItemService {
 
     public @Nonnull ItemResult consume(
             @Nullable ItemStack item, int amount, boolean replaceConsumables, @Nonnull ConsumeContext context) {
-        ResolvedHandler resolvedHandler = resolveHandler(item);
-        if (resolvedHandler == null) {
+        VirtualItemHandler handler = resolveHandler(item);
+        if (handler == null) {
             return ItemResult.notHandled();
         }
 
-        return resolvedHandler.handler().consume(item, amount, replaceConsumables, context);
+        return handler.consume(item, amount, replaceConsumables, context);
     }
 
     public @Nonnull ItemResult getRemainder(@Nullable ItemStack item, @Nonnull RemainderContext context) {
-        ResolvedHandler resolvedHandler = resolveHandler(item);
-        if (resolvedHandler == null) {
+        VirtualItemHandler handler = resolveHandler(item);
+        if (handler == null) {
             return ItemResult.notHandled();
         }
 
-        return resolvedHandler.handler().getRemainder(item, context);
+        return handler.getRemainder(item, context);
     }
 
     public boolean fits(
@@ -483,149 +335,38 @@ public final class VirtualItemService {
         return false;
     }
 
-    private @Nullable ResolvedHandler resolveHandler(@Nullable ItemStack item) {
+    /**
+     * Resolve the {@link VirtualItemHandler} for the given stack by looking up the
+     * {@link SlimefunItem} and checking whether it has a registered handler that claims the stack.
+     *
+     * @param item
+     *            The stack to inspect
+     *
+     * @return The handler, or {@code null} if none claims this stack
+     */
+    private @Nullable VirtualItemHandler resolveHandler(@Nullable ItemStack item) {
         if (item == null || item.getType().isAir()) {
             return null;
         }
 
-        SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
-        if (slimefunItem != null) {
-            return resolveSlimefunHandler(slimefunItem, item);
-        }
-
-        String ownedItem = getStoredItemOwner(item);
-        if (ownedItem != null) {
-            return resolveOwnedItemHandler(ownedItem, item);
-        }
-
-        String ownedAddon = getStoredAddonOwner(item);
-        if (ownedAddon != null) {
-            return resolveOwnedAddonHandler(ownedAddon, item);
-        }
-
-        return null;
-    }
-
-    private @Nullable ResolvedHandler resolveSlimefunHandler(@Nonnull SlimefunItem item, @Nonnull ItemStack stack) {
-        String addonKey = getAddonKey(item.getAddon());
-
-        VirtualItemHandler itemHandler = itemHandlers.get(item.getId());
-        if (itemHandler != null && itemHandler.isVirtualItem(stack)) {
-            return new ResolvedHandler(itemHandler, addonKey);
-        }
-
-        VirtualItemHandler addonHandler = addonHandlers.get(addonKey);
-        if (addonHandler != null && addonHandler.isVirtualItem(stack)) {
-            return new ResolvedHandler(addonHandler, addonKey);
-        }
-
-        return null;
-    }
-
-    private @Nullable ResolvedHandler resolveOwnedItemHandler(@Nonnull String itemId, @Nonnull ItemStack item) {
-        VirtualItemHandler itemHandler = itemHandlers.get(itemId);
-        SlimefunItem slimefunItem = SlimefunItem.getById(itemId);
-        if (slimefunItem == null || slimefunItem.getState() == ItemState.UNREGISTERED) {
+        SlimefunItem sfItem = SlimefunItem.getByItem(item);
+        if (sfItem == null) {
             return null;
         }
 
-        String addonKey = getAddonKey(slimefunItem);
-
-        if (itemHandler != null && itemHandler.isVirtualItem(item)) {
-            return new ResolvedHandler(itemHandler, addonKey);
-        }
-
-        VirtualItemHandler addonHandler = addonHandlers.get(addonKey);
-        if (addonHandler != null && addonHandler.isVirtualItem(item)) {
-            return new ResolvedHandler(addonHandler, addonKey);
-        }
-
-        return null;
-    }
-
-    private @Nullable ResolvedHandler resolveOwnedAddonHandler(@Nonnull String owner, @Nonnull ItemStack item) {
-        VirtualItemHandler handler = addonHandlers.get(owner);
-        if (handler == null || !handler.isVirtualItem(item)) {
+        Optional<ItemHandler> opt = sfItem.getHandlers().stream()
+                .filter(h -> h instanceof VirtualItemHandler)
+                .findFirst();
+        if (opt.isEmpty()) {
             return null;
         }
 
-        return new ResolvedHandler(handler, owner);
-    }
-
-    private @Nullable VirtualItemHandler resolveSharedHandler(
-            @Nonnull ResolvedHandler left, @Nonnull ResolvedHandler right) {
-        if (left.handler() == right.handler()) {
-            return left.handler();
-        }
-
-        if (left.addonKey().equals(right.addonKey())) {
-            return addonHandlers.get(left.addonKey());
-        }
-
-        return null;
-    }
-
-    private @Nullable String getStoredAddonOwner(@Nonnull ItemStack item) {
-        if (!item.hasItemMeta()) {
+        VirtualItemHandler handler = (VirtualItemHandler) opt.get();
+        if (!handler.isVirtualItem(item)) {
             return null;
         }
 
-        ItemMeta meta = item.getItemMeta();
-        if (meta == null) {
-            return null;
-        }
-
-        PersistentDataContainer container = meta.getPersistentDataContainer();
-        return container.get(getAddonOwnerKey(), PersistentDataType.STRING);
-    }
-
-    private @Nullable String getStoredItemOwner(@Nonnull ItemStack item) {
-        if (!item.hasItemMeta()) {
-            return null;
-        }
-
-        ItemMeta meta = item.getItemMeta();
-        if (meta == null) {
-            return null;
-        }
-
-        PersistentDataContainer container = meta.getPersistentDataContainer();
-        return container.get(getItemOwnerKey(), PersistentDataType.STRING);
-    }
-
-    private @Nonnull NamespacedKey getAddonOwnerKey() {
-        NamespacedKey currentKey = addonOwnerKey;
-        if (currentKey == null) {
-            currentKey = new NamespacedKey(Slimefun.instance(), ADDON_OWNER_KEY);
-            addonOwnerKey = currentKey;
-        }
-
-        return currentKey;
-    }
-
-    private @Nonnull NamespacedKey getItemOwnerKey() {
-        NamespacedKey currentKey = itemOwnerKey;
-        if (currentKey == null) {
-            currentKey = new NamespacedKey(Slimefun.instance(), ITEM_OWNER_KEY);
-            itemOwnerKey = currentKey;
-        }
-
-        return currentKey;
-    }
-
-    private boolean addonOwnsItem(@Nonnull String addonKey, @Nonnull String itemId) {
-        SlimefunItem slimefunItem = SlimefunItem.getById(itemId);
-        return slimefunItem != null
-                && slimefunItem.getState() != ItemState.UNREGISTERED
-                && addonKey.equals(getAddonKey(slimefunItem));
-    }
-
-    private @Nonnull String getAddonKey(@Nonnull SlimefunAddon addon) {
-        return addon.getName().toLowerCase(Locale.ROOT);
-    }
-
-    private @Nonnull String getAddonKey(@Nonnull SlimefunItem item) {
-        return getAddonKey(item.getAddon());
+        return handler;
     }
 
     private int[] resolveSlots(int inventorySize, int... slots) {
@@ -642,6 +383,4 @@ public final class VirtualItemService {
 
         return resolvedSlots;
     }
-
-    private record ResolvedHandler(@Nonnull VirtualItemHandler handler, @Nonnull String addonKey) {}
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
@@ -2,6 +2,8 @@ package io.github.thebusybiscuit.slimefun4.core.services;
 
 import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.bakedlibs.dough.items.ItemUtils;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler;
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.AdmissionResult;
@@ -11,53 +13,189 @@ import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.I
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ItemResult;
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.MatchContext;
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.RemainderContext;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.Validate;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 
-/**
- * Central access point for a single virtual item hook.
- *
- * <p>This service is intentionally lightweight. If no handler is registered, or if the active
- * handler reports that a stack is not virtual, all helper methods fall back to Slimefun's original
- * behavior.
- */
 public final class VirtualItemService {
 
-    private volatile @Nullable VirtualItemHandler handler;
+    private static final String ADDON_OWNER_KEY = "virtual_item_owner_addon";
+    private static final String ITEM_OWNER_KEY = "virtual_item_owner_item";
 
-    public void setHandler(@Nullable VirtualItemHandler handler) {
-        this.handler = handler;
+    private final Map<String, VirtualItemHandler> addonHandlers = new ConcurrentHashMap<>();
+    private final Map<String, VirtualItemHandler> itemHandlers = new ConcurrentHashMap<>();
+
+    private volatile @Nullable NamespacedKey addonOwnerKey;
+    private volatile @Nullable NamespacedKey itemOwnerKey;
+
+    public void registerHandler(@Nonnull SlimefunAddon addon, @Nonnull VirtualItemHandler handler) {
+        Validate.notNull(addon, "The addon cannot be null");
+        Validate.notNull(handler, "The handler cannot be null");
+        addonHandlers.put(getAddonKey(addon), handler);
     }
 
-    public @Nullable VirtualItemHandler getHandler() {
-        return handler;
+    public void unregisterHandler(@Nonnull SlimefunAddon addon) {
+        Validate.notNull(addon, "The addon cannot be null");
+        addonHandlers.remove(getAddonKey(addon));
+    }
+
+    public void clearHandlers(@Nonnull SlimefunAddon addon) {
+        Validate.notNull(addon, "The addon cannot be null");
+
+        String addonKey = getAddonKey(addon);
+        addonHandlers.remove(addonKey);
+
+        for (String itemId : itemHandlers.keySet()) {
+            if (addonOwnsItem(addonKey, itemId)) {
+                itemHandlers.remove(itemId);
+            }
+        }
+    }
+
+    public @Nullable VirtualItemHandler getHandler(@Nonnull SlimefunAddon addon) {
+        Validate.notNull(addon, "The addon cannot be null");
+        return addonHandlers.get(getAddonKey(addon));
+    }
+
+    public boolean hasHandler(@Nonnull SlimefunAddon addon) {
+        return getHandler(addon) != null;
+    }
+
+    public void registerHandler(@Nonnull SlimefunItem item, @Nonnull VirtualItemHandler handler) {
+        Validate.notNull(item, "The SlimefunItem cannot be null");
+        Validate.notNull(handler, "The handler cannot be null");
+        Validate.isTrue(
+                item.getState() != ItemState.UNREGISTERED,
+                "The SlimefunItem must be registered before assigning a virtual item handler");
+
+        itemHandlers.put(item.getId(), handler);
+    }
+
+    public void unregisterHandler(@Nonnull SlimefunItem item) {
+        Validate.notNull(item, "The SlimefunItem cannot be null");
+        itemHandlers.remove(item.getId());
+    }
+
+    public @Nullable VirtualItemHandler getHandler(@Nonnull SlimefunItem item) {
+        Validate.notNull(item, "The SlimefunItem cannot be null");
+
+        VirtualItemHandler itemHandler = itemHandlers.get(item.getId());
+        if (itemHandler != null) {
+            return itemHandler;
+        }
+
+        if (item.getState() == ItemState.UNREGISTERED) {
+            return null;
+        }
+
+        return addonHandlers.get(getAddonKey(item.getAddon()));
+    }
+
+    public boolean hasHandler(@Nonnull SlimefunItem item) {
+        return getHandler(item) != null;
     }
 
     public boolean hasHandler() {
-        return handler != null;
+        return !addonHandlers.isEmpty() || !itemHandlers.isEmpty();
+    }
+
+    public void setOwner(@Nonnull ItemStack item, @Nonnull SlimefunAddon addon) {
+        Validate.notNull(item, "The item cannot be null");
+        Validate.notNull(addon, "The addon cannot be null");
+
+        ItemMeta meta = item.getItemMeta();
+        Validate.notNull(meta, "The item meta cannot be null");
+        setOwner(meta, addon);
+        item.setItemMeta(meta);
+    }
+
+    public void setOwner(@Nonnull ItemMeta meta, @Nonnull SlimefunAddon addon) {
+        Validate.notNull(meta, "The item meta cannot be null");
+        Validate.notNull(addon, "The addon cannot be null");
+
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        container.remove(getItemOwnerKey());
+        container.set(getAddonOwnerKey(), PersistentDataType.STRING, getAddonKey(addon));
+    }
+
+    public void setOwner(@Nonnull ItemStack item, @Nonnull SlimefunItem slimefunItem) {
+        Validate.notNull(item, "The item cannot be null");
+        Validate.notNull(slimefunItem, "The SlimefunItem cannot be null");
+
+        ItemMeta meta = item.getItemMeta();
+        Validate.notNull(meta, "The item meta cannot be null");
+        setOwner(meta, slimefunItem);
+        item.setItemMeta(meta);
+    }
+
+    public void setOwner(@Nonnull ItemMeta meta, @Nonnull SlimefunItem slimefunItem) {
+        Validate.notNull(meta, "The item meta cannot be null");
+        Validate.notNull(slimefunItem, "The SlimefunItem cannot be null");
+        Validate.isTrue(
+                slimefunItem.getState() != ItemState.UNREGISTERED,
+                "The SlimefunItem must be registered before assigning it as a virtual item owner");
+
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        container.remove(getAddonOwnerKey());
+        container.set(getItemOwnerKey(), PersistentDataType.STRING, slimefunItem.getId());
+    }
+
+    public void clearOwner(@Nonnull ItemStack item) {
+        Validate.notNull(item, "The item cannot be null");
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+
+        clearOwner(meta);
+        item.setItemMeta(meta);
+    }
+
+    public void clearOwner(@Nonnull ItemMeta meta) {
+        Validate.notNull(meta, "The item meta cannot be null");
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        container.remove(getAddonOwnerKey());
+        container.remove(getItemOwnerKey());
     }
 
     public boolean isVirtualItem(@Nullable ItemStack item) {
-        VirtualItemHandler currentHandler = handler;
-        return currentHandler != null && currentHandler.isVirtualItem(item);
+        return resolveHandler(item) != null;
     }
 
     public @Nonnull ComparisonResult matches(
             @Nullable ItemStack left, @Nullable ItemStack right, @Nonnull MatchContext context) {
-        VirtualItemHandler currentHandler = handler;
-        if (currentHandler == null || !isHookRelevant(currentHandler, left, right)) {
+        ResolvedHandler leftHandler = resolveHandler(left);
+        ResolvedHandler rightHandler = resolveHandler(right);
+
+        if (leftHandler == null && rightHandler == null) {
             return ComparisonResult.NOT_HANDLED;
         }
 
-        return currentHandler.matches(left, right, context);
+        if (leftHandler != null && rightHandler != null) {
+            VirtualItemHandler sharedHandler = resolveSharedHandler(leftHandler, rightHandler);
+            if (sharedHandler == null) {
+                return ComparisonResult.NO_MATCH;
+            }
+
+            return sharedHandler.matches(left, right, context);
+        }
+
+        return (leftHandler != null ? leftHandler.handler() : rightHandler.handler()).matches(left, right, context);
     }
 
     public boolean isSimilar(
@@ -80,9 +218,9 @@ public final class VirtualItemService {
 
     public boolean matchesPredicate(
             @Nonnull ItemStack item, @Nonnull Predicate<ItemStack> predicate, @Nonnull MatchContext context) {
-        VirtualItemHandler currentHandler = handler;
-        if (currentHandler != null && currentHandler.isVirtualItem(item)) {
-            ComparisonResult comparison = currentHandler.matchesPredicate(item, predicate, context);
+        ResolvedHandler resolvedHandler = resolveHandler(item);
+        if (resolvedHandler != null) {
+            ComparisonResult comparison = resolvedHandler.handler().matchesPredicate(item, predicate, context);
             if (comparison == ComparisonResult.MATCH) {
                 return true;
             }
@@ -98,21 +236,21 @@ public final class VirtualItemService {
     public int getMaxStackSize(@Nonnull ItemStack item, @Nonnull InventoryContext context, int defaultMaxStackSize) {
         Validate.notNull(item, "The item cannot be null");
 
-        VirtualItemHandler currentHandler = handler;
-        if (currentHandler == null || !currentHandler.isVirtualItem(item)) {
+        ResolvedHandler resolvedHandler = resolveHandler(item);
+        if (resolvedHandler == null) {
             return defaultMaxStackSize;
         }
 
-        return Math.max(1, currentHandler.getMaxStackSize(item, context, defaultMaxStackSize));
+        return Math.max(1, resolvedHandler.handler().getMaxStackSize(item, context, defaultMaxStackSize));
     }
 
     public @Nonnull AdmissionResult allows(@Nonnull ItemStack item, @Nonnull InventoryContext context) {
-        VirtualItemHandler currentHandler = handler;
-        if (currentHandler == null || !currentHandler.isVirtualItem(item)) {
+        ResolvedHandler resolvedHandler = resolveHandler(item);
+        if (resolvedHandler == null) {
             return AdmissionResult.NOT_HANDLED;
         }
 
-        return currentHandler.allows(item, context);
+        return resolvedHandler.handler().allows(item, context);
     }
 
     public boolean canInsertIntoEmptySlot(@Nonnull ItemStack item, @Nonnull InventoryContext context) {
@@ -121,21 +259,21 @@ public final class VirtualItemService {
 
     public @Nonnull ItemResult consume(
             @Nullable ItemStack item, int amount, boolean replaceConsumables, @Nonnull ConsumeContext context) {
-        VirtualItemHandler currentHandler = handler;
-        if (item == null || currentHandler == null || !currentHandler.isVirtualItem(item)) {
+        ResolvedHandler resolvedHandler = resolveHandler(item);
+        if (resolvedHandler == null) {
             return ItemResult.notHandled();
         }
 
-        return currentHandler.consume(item, amount, replaceConsumables, context);
+        return resolvedHandler.handler().consume(item, amount, replaceConsumables, context);
     }
 
     public @Nonnull ItemResult getRemainder(@Nullable ItemStack item, @Nonnull RemainderContext context) {
-        VirtualItemHandler currentHandler = handler;
-        if (item == null || currentHandler == null || !currentHandler.isVirtualItem(item)) {
+        ResolvedHandler resolvedHandler = resolveHandler(item);
+        if (resolvedHandler == null) {
             return ItemResult.notHandled();
         }
 
-        return currentHandler.getRemainder(item, context);
+        return resolvedHandler.handler().getRemainder(item, context);
     }
 
     public boolean fits(
@@ -335,24 +473,159 @@ public final class VirtualItemService {
         return ItemUtils.canStack(wrapper, existing);
     }
 
-    private boolean isHookRelevant(
-            @Nonnull VirtualItemHandler currentHandler, @Nullable ItemStack left, @Nullable ItemStack right) {
-        return currentHandler.isVirtualItem(left) || currentHandler.isVirtualItem(right);
-    }
-
     private boolean hasVirtualItemsInSlots(@Nonnull Inventory inventory, int... slots) {
-        VirtualItemHandler currentHandler = handler;
-        if (currentHandler == null) {
-            return false;
-        }
-
         for (int slot : resolveSlots(inventory.getSize(), slots)) {
-            if (currentHandler.isVirtualItem(inventory.getItem(slot))) {
+            if (resolveHandler(inventory.getItem(slot)) != null) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private @Nullable ResolvedHandler resolveHandler(@Nullable ItemStack item) {
+        if (item == null || item.getType().isAir()) {
+            return null;
+        }
+
+        SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
+        if (slimefunItem != null) {
+            return resolveSlimefunHandler(slimefunItem, item);
+        }
+
+        String ownedItem = getStoredItemOwner(item);
+        if (ownedItem != null) {
+            return resolveOwnedItemHandler(ownedItem, item);
+        }
+
+        String ownedAddon = getStoredAddonOwner(item);
+        if (ownedAddon != null) {
+            return resolveOwnedAddonHandler(ownedAddon, item);
+        }
+
+        return null;
+    }
+
+    private @Nullable ResolvedHandler resolveSlimefunHandler(@Nonnull SlimefunItem item, @Nonnull ItemStack stack) {
+        String addonKey = getAddonKey(item.getAddon());
+
+        VirtualItemHandler itemHandler = itemHandlers.get(item.getId());
+        if (itemHandler != null && itemHandler.isVirtualItem(stack)) {
+            return new ResolvedHandler(itemHandler, addonKey);
+        }
+
+        VirtualItemHandler addonHandler = addonHandlers.get(addonKey);
+        if (addonHandler != null && addonHandler.isVirtualItem(stack)) {
+            return new ResolvedHandler(addonHandler, addonKey);
+        }
+
+        return null;
+    }
+
+    private @Nullable ResolvedHandler resolveOwnedItemHandler(@Nonnull String itemId, @Nonnull ItemStack item) {
+        VirtualItemHandler itemHandler = itemHandlers.get(itemId);
+        SlimefunItem slimefunItem = SlimefunItem.getById(itemId);
+        if (slimefunItem == null || slimefunItem.getState() == ItemState.UNREGISTERED) {
+            return null;
+        }
+
+        String addonKey = getAddonKey(slimefunItem);
+
+        if (itemHandler != null && itemHandler.isVirtualItem(item)) {
+            return new ResolvedHandler(itemHandler, addonKey);
+        }
+
+        VirtualItemHandler addonHandler = addonHandlers.get(addonKey);
+        if (addonHandler != null && addonHandler.isVirtualItem(item)) {
+            return new ResolvedHandler(addonHandler, addonKey);
+        }
+
+        return null;
+    }
+
+    private @Nullable ResolvedHandler resolveOwnedAddonHandler(@Nonnull String owner, @Nonnull ItemStack item) {
+        VirtualItemHandler handler = addonHandlers.get(owner);
+        if (handler == null || !handler.isVirtualItem(item)) {
+            return null;
+        }
+
+        return new ResolvedHandler(handler, owner);
+    }
+
+    private @Nullable VirtualItemHandler resolveSharedHandler(
+            @Nonnull ResolvedHandler left, @Nonnull ResolvedHandler right) {
+        if (left.handler() == right.handler()) {
+            return left.handler();
+        }
+
+        if (left.addonKey().equals(right.addonKey())) {
+            return addonHandlers.get(left.addonKey());
+        }
+
+        return null;
+    }
+
+    private @Nullable String getStoredAddonOwner(@Nonnull ItemStack item) {
+        if (!item.hasItemMeta()) {
+            return null;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return null;
+        }
+
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        return container.get(getAddonOwnerKey(), PersistentDataType.STRING);
+    }
+
+    private @Nullable String getStoredItemOwner(@Nonnull ItemStack item) {
+        if (!item.hasItemMeta()) {
+            return null;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return null;
+        }
+
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        return container.get(getItemOwnerKey(), PersistentDataType.STRING);
+    }
+
+    private @Nonnull NamespacedKey getAddonOwnerKey() {
+        NamespacedKey currentKey = addonOwnerKey;
+        if (currentKey == null) {
+            currentKey = new NamespacedKey(Slimefun.instance(), ADDON_OWNER_KEY);
+            addonOwnerKey = currentKey;
+        }
+
+        return currentKey;
+    }
+
+    private @Nonnull NamespacedKey getItemOwnerKey() {
+        NamespacedKey currentKey = itemOwnerKey;
+        if (currentKey == null) {
+            currentKey = new NamespacedKey(Slimefun.instance(), ITEM_OWNER_KEY);
+            itemOwnerKey = currentKey;
+        }
+
+        return currentKey;
+    }
+
+    private boolean addonOwnsItem(@Nonnull String addonKey, @Nonnull String itemId) {
+        SlimefunItem slimefunItem = SlimefunItem.getById(itemId);
+        return slimefunItem != null
+                && slimefunItem.getState() != ItemState.UNREGISTERED
+                && addonKey.equals(getAddonKey(slimefunItem));
+    }
+
+    private @Nonnull String getAddonKey(@Nonnull SlimefunAddon addon) {
+        return addon.getName().toLowerCase(Locale.ROOT);
+    }
+
+    private @Nonnull String getAddonKey(@Nonnull SlimefunItem item) {
+        return getAddonKey(item.getAddon());
     }
 
     private int[] resolveSlots(int inventorySize, int... slots) {
@@ -369,4 +642,6 @@ public final class VirtualItemService {
 
         return resolvedSlots;
     }
+
+    private record ResolvedHandler(@Nonnull VirtualItemHandler handler, @Nonnull String addonKey) {}
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
@@ -138,7 +138,7 @@ public final class VirtualItemService {
 
     public boolean fits(
             @Nonnull Inventory inventory, @Nonnull ItemStack item, @Nonnull InventoryContext context, int... slots) {
-        if (!isVirtualItem(item)) {
+        if (!isVirtualItem(item) && SlimefunItem.getByItem(item) == null) {
             if (slots.length == 0) {
                 return InvUtils.fits(inventory, item);
             }
@@ -334,7 +334,9 @@ public final class VirtualItemService {
 
     private int[] resolveSlots(int inventorySize, int... slots) {
         if (slots.length > 0) {
-            return slots;
+            return Arrays.stream(slots)
+                    .filter(slot -> slot >= 0 && slot < inventorySize)
+                    .toArray();
         }
 
         int[] resolvedSlots = new int[inventorySize];

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
@@ -1,0 +1,296 @@
+package io.github.thebusybiscuit.slimefun4.core.services;
+
+import io.github.bakedlibs.dough.inventory.InvUtils;
+import io.github.bakedlibs.dough.items.ItemUtils;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.AdmissionResult;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ComparisonResult;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ConsumeContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ItemResult;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.MatchContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.RemainderContext;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.Validate;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Central access point for a single virtual item hook.
+ *
+ * <p>This service is intentionally lightweight. If no handler is registered, or if the active
+ * handler reports that a stack is not virtual, all helper methods fall back to Slimefun's original
+ * behavior.
+ */
+public final class VirtualItemService {
+
+    private volatile @Nullable VirtualItemHandler handler;
+
+    public void setHandler(@Nullable VirtualItemHandler handler) {
+        this.handler = handler;
+    }
+
+    public @Nullable VirtualItemHandler getHandler() {
+        return handler;
+    }
+
+    public boolean hasHandler() {
+        return handler != null;
+    }
+
+    public boolean isVirtualItem(@Nullable ItemStack item) {
+        VirtualItemHandler currentHandler = handler;
+        return currentHandler != null && currentHandler.isVirtualItem(item);
+    }
+
+    public @Nonnull ComparisonResult matches(
+            @Nullable ItemStack left, @Nullable ItemStack right, @Nonnull MatchContext context) {
+        VirtualItemHandler currentHandler = handler;
+        if (currentHandler == null || !isHookRelevant(currentHandler, left, right)) {
+            return ComparisonResult.NOT_HANDLED;
+        }
+
+        return currentHandler.matches(left, right, context);
+    }
+
+    public boolean isSimilar(
+            @Nullable ItemStack left,
+            @Nullable ItemStack right,
+            @Nonnull MatchContext context,
+            boolean checkLore,
+            boolean checkAmount) {
+        ComparisonResult comparison = matches(left, right, context);
+        if (comparison == ComparisonResult.MATCH) {
+            return true;
+        }
+
+        if (comparison == ComparisonResult.NO_MATCH) {
+            return false;
+        }
+
+        return SlimefunUtils.isItemSimilarWithoutVirtualItems(left, right, checkLore, checkAmount);
+    }
+
+    public boolean matchesPredicate(
+            @Nonnull ItemStack item, @Nonnull Predicate<ItemStack> predicate, @Nonnull MatchContext context) {
+        if (predicate.test(item)) {
+            return true;
+        }
+
+        VirtualItemHandler currentHandler = handler;
+        if (currentHandler == null || !currentHandler.isVirtualItem(item)) {
+            return false;
+        }
+
+        ComparisonResult comparison = currentHandler.matchesPredicate(item, predicate, context);
+        return comparison == ComparisonResult.MATCH;
+    }
+
+    public int getMaxStackSize(@Nonnull ItemStack item, @Nonnull InventoryContext context, int defaultMaxStackSize) {
+        Validate.notNull(item, "The item cannot be null");
+
+        VirtualItemHandler currentHandler = handler;
+        if (currentHandler == null || !currentHandler.isVirtualItem(item)) {
+            return defaultMaxStackSize;
+        }
+
+        return Math.max(1, currentHandler.getMaxStackSize(item, context, defaultMaxStackSize));
+    }
+
+    public @Nonnull AdmissionResult allows(@Nonnull ItemStack item, @Nonnull InventoryContext context) {
+        VirtualItemHandler currentHandler = handler;
+        if (currentHandler == null || !currentHandler.isVirtualItem(item)) {
+            return AdmissionResult.NOT_HANDLED;
+        }
+
+        return currentHandler.allows(item, context);
+    }
+
+    public boolean canInsertIntoEmptySlot(@Nonnull ItemStack item, @Nonnull InventoryContext context) {
+        return allows(item, context) != AdmissionResult.DENY;
+    }
+
+    public @Nonnull ItemResult consume(
+            @Nullable ItemStack item, int amount, boolean replaceConsumables, @Nonnull ConsumeContext context) {
+        VirtualItemHandler currentHandler = handler;
+        if (item == null || currentHandler == null || !currentHandler.isVirtualItem(item)) {
+            return ItemResult.notHandled();
+        }
+
+        return currentHandler.consume(item, amount, replaceConsumables, context);
+    }
+
+    public @Nonnull ItemResult getRemainder(@Nullable ItemStack item, @Nonnull RemainderContext context) {
+        VirtualItemHandler currentHandler = handler;
+        if (item == null || currentHandler == null || !currentHandler.isVirtualItem(item)) {
+            return ItemResult.notHandled();
+        }
+
+        return currentHandler.getRemainder(item, context);
+    }
+
+    public boolean fits(
+            @Nonnull Inventory inventory, @Nonnull ItemStack item, @Nonnull InventoryContext context, int... slots) {
+        if (!isVirtualItem(item)) {
+            if (slots.length == 0) {
+                return InvUtils.fits(inventory, item);
+            }
+
+            return InvUtils.fits(inventory, ItemStackWrapper.wrap(item), slots);
+        }
+
+        ItemStack[] contents = Arrays.stream(inventory.getContents())
+                .map(stack -> stack == null ? null : stack.clone())
+                .toArray(ItemStack[]::new);
+        return insertIntoSnapshot(contents, inventory.getMaxStackSize(), item, context, slots) <= 0;
+    }
+
+    public boolean fitAll(
+            @Nonnull Inventory inventory, @Nonnull ItemStack[] items, @Nonnull InventoryContext context, int... slots) {
+        boolean hasVirtualItems = false;
+        for (ItemStack item : items) {
+            if (item != null && isVirtualItem(item)) {
+                hasVirtualItems = true;
+                break;
+            }
+        }
+
+        if (!hasVirtualItems) {
+            return InvUtils.fitAll(inventory, items, slots);
+        }
+
+        ItemStack[] contents = Arrays.stream(inventory.getContents())
+                .map(stack -> stack == null ? null : stack.clone())
+                .toArray(ItemStack[]::new);
+
+        for (ItemStack item : items) {
+            if (item == null || item.getType().isAir()) {
+                continue;
+            }
+
+            if (insertIntoSnapshot(contents, inventory.getMaxStackSize(), item, context, slots) > 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public @Nullable ItemStack addItem(
+            @Nonnull Inventory inventory, @Nonnull ItemStack item, @Nonnull InventoryContext context, int... slots) {
+        Validate.notNull(item, "The item cannot be null");
+
+        if (!isVirtualItem(item) && slots.length == 0) {
+            Map<Integer, ItemStack> leftovers = inventory.addItem(item.clone());
+            if (leftovers.isEmpty()) {
+                return null;
+            }
+
+            return leftovers.values().iterator().next();
+        }
+
+        ItemStack[] contents = Arrays.stream(inventory.getContents())
+                .map(stack -> stack == null ? null : stack.clone())
+                .toArray(ItemStack[]::new);
+        int amountLeft = insertIntoSnapshot(contents, inventory.getMaxStackSize(), item, context, slots);
+        inventory.setContents(contents);
+
+        if (amountLeft <= 0) {
+            return null;
+        }
+
+        ItemStack remainder = item.clone();
+        remainder.setAmount(amountLeft);
+        return remainder;
+    }
+
+    private int insertIntoSnapshot(
+            @Nonnull ItemStack[] contents,
+            int inventoryMaxStackSize,
+            @Nonnull ItemStack item,
+            @Nonnull InventoryContext context,
+            int... slots) {
+        int amountLeft = item.getAmount();
+        int[] resolvedSlots = resolveSlots(contents.length, slots);
+
+        for (int slot : resolvedSlots) {
+            ItemStack itemInSlot = contents[slot];
+
+            if (itemInSlot == null || itemInSlot.getType().isAir()) {
+                if (!canInsertIntoEmptySlot(item, context)) {
+                    continue;
+                }
+
+                int maxStackSize =
+                        Math.min(getMaxStackSize(item, context, item.getMaxStackSize()), inventoryMaxStackSize);
+                int movedAmount = Math.min(amountLeft, maxStackSize);
+
+                ItemStack inserted = item.clone();
+                inserted.setAmount(movedAmount);
+                contents[slot] = inserted;
+                amountLeft -= movedAmount;
+            } else if (canMerge(itemInSlot, item)) {
+                int maxStackSize = Math.min(
+                        getMaxStackSize(itemInSlot, context, itemInSlot.getMaxStackSize()), inventoryMaxStackSize);
+                int freeSpace = maxStackSize - itemInSlot.getAmount();
+
+                if (freeSpace <= 0) {
+                    continue;
+                }
+
+                int movedAmount = Math.min(amountLeft, freeSpace);
+                itemInSlot.setAmount(itemInSlot.getAmount() + movedAmount);
+                amountLeft -= movedAmount;
+            }
+
+            if (amountLeft <= 0) {
+                return 0;
+            }
+        }
+
+        return amountLeft;
+    }
+
+    private boolean canMerge(@Nonnull ItemStack existing, @Nonnull ItemStack incoming) {
+        ComparisonResult comparison = matches(existing, incoming, MatchContext.STACK_MERGE);
+        if (comparison == ComparisonResult.MATCH) {
+            return true;
+        }
+
+        if (comparison == ComparisonResult.NO_MATCH) {
+            return false;
+        }
+
+        ItemStackWrapper wrapper = ItemStackWrapper.wrap(incoming);
+        if (SlimefunItem.getByItem(existing) != null || SlimefunItem.getByItem(incoming) != null) {
+            return SlimefunUtils.isItemSimilarWithoutVirtualItems(existing, wrapper, true, false);
+        }
+
+        return ItemUtils.canStack(wrapper, existing);
+    }
+
+    private boolean isHookRelevant(
+            @Nonnull VirtualItemHandler currentHandler, @Nullable ItemStack left, @Nullable ItemStack right) {
+        return currentHandler.isVirtualItem(left) || currentHandler.isVirtualItem(right);
+    }
+
+    private int[] resolveSlots(int inventorySize, int... slots) {
+        if (slots.length > 0) {
+            return slots;
+        }
+
+        int[] resolvedSlots = new int[inventorySize];
+        for (int slot = 0; slot < inventorySize; slot++) {
+            resolvedSlots[slot] = slot;
+        }
+
+        return resolvedSlots;
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
@@ -44,6 +44,16 @@ public final class VirtualItemService {
                 return leftHandler.matches(left, right, context);
             }
 
+            ComparisonResult leftResult = leftHandler.matches(left, right, context);
+            if (leftResult != ComparisonResult.NOT_HANDLED) {
+                return leftResult;
+            }
+
+            ComparisonResult rightResult = rightHandler.matches(left, right, context);
+            if (rightResult != ComparisonResult.NOT_HANDLED) {
+                return rightResult;
+            }
+
             return ComparisonResult.NO_MATCH;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
@@ -195,7 +195,7 @@ public final class VirtualItemService {
 
         boolean hasVirtualItems = hasVirtualItemsInSlots(inventory, slots);
 
-        if (!hasVirtualItems && !isVirtualItem(item) && slots.length == 0) {
+        if (!hasVirtualItems && !isVirtualItem(item) && SlimefunItem.getByItem(item) == null && slots.length == 0) {
             Map<Integer, ItemStack> leftovers = inventory.addItem(item.clone());
             if (leftovers.isEmpty()) {
                 return null;
@@ -204,7 +204,7 @@ public final class VirtualItemService {
             return leftovers.values().iterator().next();
         }
 
-        if (!hasVirtualItems && !isVirtualItem(item) && slots.length > 0) {
+        if (!hasVirtualItems && !isVirtualItem(item) && SlimefunItem.getByItem(item) == null && slots.length > 0) {
             return addItemDirectly(inventory, item, context, slots);
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/VirtualItemService.java
@@ -80,17 +80,19 @@ public final class VirtualItemService {
 
     public boolean matchesPredicate(
             @Nonnull ItemStack item, @Nonnull Predicate<ItemStack> predicate, @Nonnull MatchContext context) {
-        if (predicate.test(item)) {
-            return true;
-        }
-
         VirtualItemHandler currentHandler = handler;
-        if (currentHandler == null || !currentHandler.isVirtualItem(item)) {
-            return false;
+        if (currentHandler != null && currentHandler.isVirtualItem(item)) {
+            ComparisonResult comparison = currentHandler.matchesPredicate(item, predicate, context);
+            if (comparison == ComparisonResult.MATCH) {
+                return true;
+            }
+
+            if (comparison == ComparisonResult.NO_MATCH) {
+                return false;
+            }
         }
 
-        ComparisonResult comparison = currentHandler.matchesPredicate(item, predicate, context);
-        return comparison == ComparisonResult.MATCH;
+        return predicate.test(item);
     }
 
     public int getMaxStackSize(@Nonnull ItemStack item, @Nonnull InventoryContext context, int defaultMaxStackSize) {
@@ -138,7 +140,7 @@ public final class VirtualItemService {
 
     public boolean fits(
             @Nonnull Inventory inventory, @Nonnull ItemStack item, @Nonnull InventoryContext context, int... slots) {
-        if (!isVirtualItem(item) && SlimefunItem.getByItem(item) == null) {
+        if (!hasVirtualItemsInSlots(inventory, slots) && !isVirtualItem(item) && SlimefunItem.getByItem(item) == null) {
             if (slots.length == 0) {
                 return InvUtils.fits(inventory, item);
             }
@@ -160,6 +162,10 @@ public final class VirtualItemService {
                 hasVirtualItems = true;
                 break;
             }
+        }
+
+        if (!hasVirtualItems) {
+            hasVirtualItems = hasVirtualItemsInSlots(inventory, slots);
         }
 
         if (!hasVirtualItems) {
@@ -187,7 +193,9 @@ public final class VirtualItemService {
             @Nonnull Inventory inventory, @Nonnull ItemStack item, @Nonnull InventoryContext context, int... slots) {
         Validate.notNull(item, "The item cannot be null");
 
-        if (!isVirtualItem(item) && slots.length == 0) {
+        boolean hasVirtualItems = hasVirtualItemsInSlots(inventory, slots);
+
+        if (!hasVirtualItems && !isVirtualItem(item) && slots.length == 0) {
             Map<Integer, ItemStack> leftovers = inventory.addItem(item.clone());
             if (leftovers.isEmpty()) {
                 return null;
@@ -196,7 +204,7 @@ public final class VirtualItemService {
             return leftovers.values().iterator().next();
         }
 
-        if (!isVirtualItem(item) && slots.length > 0) {
+        if (!hasVirtualItems && !isVirtualItem(item) && slots.length > 0) {
             return addItemDirectly(inventory, item, context, slots);
         }
 
@@ -330,6 +338,21 @@ public final class VirtualItemService {
     private boolean isHookRelevant(
             @Nonnull VirtualItemHandler currentHandler, @Nullable ItemStack left, @Nullable ItemStack right) {
         return currentHandler.isVirtualItem(left) || currentHandler.isVirtualItem(right);
+    }
+
+    private boolean hasVirtualItemsInSlots(@Nonnull Inventory inventory, int... slots) {
+        VirtualItemHandler currentHandler = handler;
+        if (currentHandler == null) {
+            return false;
+        }
+
+        for (int slot : resolveSlots(inventory.getSize(), slots)) {
+            if (currentHandler.isVirtualItem(inventory.getItem(slot))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private int[] resolveSlots(int inventorySize, int... slots) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -33,6 +33,7 @@ import io.github.thebusybiscuit.slimefun4.core.services.PerWorldSettingsService;
 import io.github.thebusybiscuit.slimefun4.core.services.PermissionsService;
 import io.github.thebusybiscuit.slimefun4.core.services.ThreadService;
 import io.github.thebusybiscuit.slimefun4.core.services.UpdaterService;
+import io.github.thebusybiscuit.slimefun4.core.services.VirtualItemService;
 import io.github.thebusybiscuit.slimefun4.core.services.github.GitHubService;
 import io.github.thebusybiscuit.slimefun4.core.services.holograms.HologramsService;
 import io.github.thebusybiscuit.slimefun4.core.services.profiler.SlimefunProfiler;
@@ -194,6 +195,7 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon, ICompat
     private final SoundService soundService = new SoundService(this);
     private final ThreadService threadService = new ThreadService(this);
     private final AnalyticsService analyticsService = new AnalyticsService(this);
+    private final VirtualItemService virtualItemService = new VirtualItemService();
 
     // Some other things we need
     private final IntegrationsManager integrations = new IntegrationsManager(this);
@@ -901,6 +903,11 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon, ICompat
     public static @Nonnull BlockDataService getBlockDataService() {
         validateInstance();
         return instance.blockDataService;
+    }
+
+    public static @Nonnull VirtualItemService getVirtualItemService() {
+        validateInstance();
+        return instance.virtualItemService;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -26,6 +26,7 @@ import io.github.thebusybiscuit.slimefun4.core.services.BackupService;
 import io.github.thebusybiscuit.slimefun4.core.services.BlockDataService;
 import io.github.thebusybiscuit.slimefun4.core.services.CustomItemDataService;
 import io.github.thebusybiscuit.slimefun4.core.services.CustomTextureService;
+import io.github.thebusybiscuit.slimefun4.core.services.ItemStackService;
 import io.github.thebusybiscuit.slimefun4.core.services.LocalizationService;
 import io.github.thebusybiscuit.slimefun4.core.services.MetricsService;
 import io.github.thebusybiscuit.slimefun4.core.services.MinecraftRecipeService;
@@ -33,7 +34,6 @@ import io.github.thebusybiscuit.slimefun4.core.services.PerWorldSettingsService;
 import io.github.thebusybiscuit.slimefun4.core.services.PermissionsService;
 import io.github.thebusybiscuit.slimefun4.core.services.ThreadService;
 import io.github.thebusybiscuit.slimefun4.core.services.UpdaterService;
-import io.github.thebusybiscuit.slimefun4.core.services.VirtualItemService;
 import io.github.thebusybiscuit.slimefun4.core.services.github.GitHubService;
 import io.github.thebusybiscuit.slimefun4.core.services.holograms.HologramsService;
 import io.github.thebusybiscuit.slimefun4.core.services.profiler.SlimefunProfiler;
@@ -195,7 +195,7 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon, ICompat
     private final SoundService soundService = new SoundService(this);
     private final ThreadService threadService = new ThreadService(this);
     private final AnalyticsService analyticsService = new AnalyticsService(this);
-    private final VirtualItemService virtualItemService = new VirtualItemService();
+    private final ItemStackService itemStackService = new ItemStackService();
 
     // Some other things we need
     private final IntegrationsManager integrations = new IntegrationsManager(this);
@@ -905,9 +905,9 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon, ICompat
         return instance.blockDataService;
     }
 
-    public static @Nonnull VirtualItemService getVirtualItemService() {
+    public static @Nonnull ItemStackService getItemStackService() {
         validateInstance();
-        return instance.virtualItemService;
+        return instance.itemStackService;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -274,7 +274,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      */
     @ParametersAreNonnullByDefault
     protected boolean matches(ItemStack item, Predicate<ItemStack> predicate) {
-        return Slimefun.getVirtualItemService().matchesPredicate(item, predicate, MatchContext.AUTO_CRAFTER_PREDICATE);
+        return Slimefun.getItemStackService().matchesPredicate(item, predicate, MatchContext.AUTO_CRAFTER_PREDICATE);
     }
 
     /**
@@ -562,7 +562,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * @return The leftover item or null if the item is fully consumed
      */
     @Nullable private ItemStack getLeftoverItem(@Nonnull ItemStack item) {
-        var virtualLeftover = Slimefun.getVirtualItemService().getRemainder(item, RemainderContext.AUTO_CRAFTER);
+        var virtualLeftover = Slimefun.getItemStackService().getRemainder(item, RemainderContext.AUTO_CRAFTER);
         if (virtualLeftover.handled()) {
             return virtualLeftover.item();
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -12,6 +12,8 @@ import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.MatchContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.RemainderContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
@@ -272,7 +274,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      */
     @ParametersAreNonnullByDefault
     protected boolean matches(ItemStack item, Predicate<ItemStack> predicate) {
-        return predicate.test(item);
+        return Slimefun.getVirtualItemService().matchesPredicate(item, predicate, MatchContext.AUTO_CRAFTER_PREDICATE);
     }
 
     /**
@@ -560,6 +562,11 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * @return The leftover item or null if the item is fully consumed
      */
     @Nullable private ItemStack getLeftoverItem(@Nonnull ItemStack item) {
+        var virtualLeftover = Slimefun.getVirtualItemService().getRemainder(item, RemainderContext.AUTO_CRAFTER);
+        if (virtualLeftover.handled()) {
+            return virtualLeftover.item();
+        }
+
         Material type = item.getType();
 
         return switch (type) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/OutputChest.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/OutputChest.java
@@ -1,12 +1,13 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.blocks;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.handlers.VanillaInventoryDropHandler;
 import io.papermc.lib.PaperLib;
 import java.util.Optional;
@@ -63,7 +64,7 @@ public class OutputChest extends SlimefunItem {
                         Inventory inv = chest.getInventory();
 
                         // Check if the Item fits into that inventory.
-                        if (InvUtils.fits(inv, item)) {
+                        if (Slimefun.getVirtualItemService().fits(inv, item, InventoryContext.OUTPUT_CHEST)) {
                             return Optional.of(inv);
                         }
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/OutputChest.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/OutputChest.java
@@ -64,7 +64,7 @@ public class OutputChest extends SlimefunItem {
                         Inventory inv = chest.getInventory();
 
                         // Check if the Item fits into that inventory.
-                        if (Slimefun.getVirtualItemService().fits(inv, item, InventoryContext.OUTPUT_CHEST)) {
+                        if (Slimefun.getItemStackService().fits(inv, item, InventoryContext.OUTPUT_CHEST)) {
                             return Optional.of(inv);
                         }
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
@@ -2,11 +2,12 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machine
 
 import city.norain.slimefun4.SlimefunExtended;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotHopperable;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedPotionType;
 import java.util.EnumMap;
 import java.util.Map;
@@ -126,7 +127,8 @@ public class AutoBrewer extends AContainer implements NotHopperable {
 
             output.setItemMeta(potion);
 
-            if (!InvUtils.fits(menu.toInventory(), output, getOutputSlots())) {
+            if (!Slimefun.getVirtualItemService()
+                    .fits(menu.toInventory(), output, InventoryContext.MACHINE_OUTPUT, getOutputSlots())) {
                 return null;
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
@@ -127,7 +127,7 @@ public class AutoBrewer extends AContainer implements NotHopperable {
 
             output.setItemMeta(potion);
 
-            if (!Slimefun.getVirtualItemService()
+            if (!Slimefun.getItemStackService()
                     .fits(menu.toInventory(), output, InventoryContext.MACHINE_OUTPUT, getOutputSlots())) {
                 return null;
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
@@ -1,10 +1,10 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.enchanting;
 
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.api.events.AutoDisenchantEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import java.util.HashMap;
@@ -65,7 +65,12 @@ public class AutoDisenchanter extends AbstractEnchantmentMachine {
             Bukkit.getPluginManager().callEvent(event);
 
             if (event.isCancelled()) {
-                if (InvUtils.fitAll(menu.toInventory(), new ItemStack[] {item}, getOutputSlots())) {
+                if (Slimefun.getVirtualItemService()
+                        .fitAll(
+                                menu.toInventory(),
+                                new ItemStack[] {item},
+                                InventoryContext.MACHINE_OUTPUT,
+                                getOutputSlots())) {
                     menu.replaceExistingItem(slot, null);
                     menu.pushItem(item, getOutputSlots());
                 }
@@ -119,7 +124,12 @@ public class AutoDisenchanter extends AbstractEnchantmentMachine {
                     new ItemStack[] {book, item},
                     new ItemStack[] {disenchantedItem, enchantedBook});
 
-            if (!InvUtils.fitAll(menu.toInventory(), recipe.getOutput(), getOutputSlots())) {
+            if (!Slimefun.getVirtualItemService()
+                    .fitAll(
+                            menu.toInventory(),
+                            recipe.getOutput(),
+                            InventoryContext.MACHINE_OUTPUT,
+                            getOutputSlots())) {
                 return null;
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
@@ -65,7 +65,7 @@ public class AutoDisenchanter extends AbstractEnchantmentMachine {
             Bukkit.getPluginManager().callEvent(event);
 
             if (event.isCancelled()) {
-                if (Slimefun.getVirtualItemService()
+                if (Slimefun.getItemStackService()
                         .fitAll(
                                 menu.toInventory(),
                                 new ItemStack[] {item},
@@ -124,7 +124,7 @@ public class AutoDisenchanter extends AbstractEnchantmentMachine {
                     new ItemStack[] {book, item},
                     new ItemStack[] {disenchantedItem, enchantedBook});
 
-            if (!Slimefun.getVirtualItemService()
+            if (!Slimefun.getItemStackService()
                     .fitAll(
                             menu.toInventory(),
                             recipe.getOutput(),

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -69,7 +69,7 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
             Bukkit.getPluginManager().callEvent(event);
 
             if (event.isCancelled()) {
-                if (Slimefun.getVirtualItemService()
+                if (Slimefun.getItemStackService()
                         .fitAll(
                                 menu.toInventory(),
                                 new ItemStack[] {item},
@@ -155,7 +155,7 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
                     new ItemStack[] {target, enchantedBook},
                     new ItemStack[] {enchantedItem, new ItemStack(Material.BOOK)});
 
-            if (!Slimefun.getVirtualItemService()
+            if (!Slimefun.getItemStackService()
                     .fitAll(
                             menu.toInventory(),
                             recipe.getOutput(),

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -1,13 +1,14 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.enchanting;
 
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.api.events.AsyncAutoEnchanterProcessEvent;
 import io.github.thebusybiscuit.slimefun4.api.events.AutoEnchantEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -68,7 +69,12 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
             Bukkit.getPluginManager().callEvent(event);
 
             if (event.isCancelled()) {
-                if (InvUtils.fitAll(menu.toInventory(), new ItemStack[] {item}, getOutputSlots())) {
+                if (Slimefun.getVirtualItemService()
+                        .fitAll(
+                                menu.toInventory(),
+                                new ItemStack[] {item},
+                                InventoryContext.MACHINE_OUTPUT,
+                                getOutputSlots())) {
                     menu.replaceExistingItem(otherSlot, null);
                     menu.pushItem(item, getOutputSlots());
                 }
@@ -149,7 +155,12 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
                     new ItemStack[] {target, enchantedBook},
                     new ItemStack[] {enchantedItem, new ItemStack(Material.BOOK)});
 
-            if (!InvUtils.fitAll(menu.toInventory(), recipe.getOutput(), getOutputSlots())) {
+            if (!Slimefun.getVirtualItemService()
+                    .fitAll(
+                            menu.toInventory(),
+                            recipe.getOutput(),
+                            InventoryContext.MACHINE_OUTPUT,
+                            getOutputSlots())) {
                 return null;
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
@@ -88,7 +88,7 @@ public class BookBinder extends AContainer {
                             new ItemStack[] {target, item},
                             new ItemStack[] {book});
 
-                    if (!Slimefun.getVirtualItemService()
+                    if (!Slimefun.getItemStackService()
                             .fitAll(
                                     menu.toInventory(),
                                     recipe.getOutput(),

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
@@ -1,11 +1,12 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.enchanting;
 
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.settings.IntRangeSetting;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -87,7 +88,12 @@ public class BookBinder extends AContainer {
                             new ItemStack[] {target, item},
                             new ItemStack[] {book});
 
-                    if (!InvUtils.fitAll(menu.toInventory(), recipe.getOutput(), getOutputSlots())) {
+                    if (!Slimefun.getVirtualItemService()
+                            .fitAll(
+                                    menu.toInventory(),
+                                    recipe.getOutput(),
+                                    InventoryContext.MACHINE_OUTPUT,
+                                    getOutputSlots())) {
                         return null;
                     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
@@ -1,7 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.entities;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -9,6 +8,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.settings.IntRangeSetting;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -133,7 +133,12 @@ public class ProduceCollector extends AContainer implements RecipeDisplayItem {
                 ItemStack item = inv.getItemInSlot(slot);
 
                 if (!SlimefunUtils.isItemSimilar(item, produce.getInput()[0], true)
-                        || !InvUtils.fits(inv.toInventory(), produce.getOutput()[0], getOutputSlots())) {
+                        || !Slimefun.getVirtualItemService()
+                                .fits(
+                                        inv.toInventory(),
+                                        produce.getOutput()[0],
+                                        InventoryContext.MACHINE_OUTPUT,
+                                        getOutputSlots())) {
                     continue;
                 }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
@@ -133,7 +133,7 @@ public class ProduceCollector extends AContainer implements RecipeDisplayItem {
                 ItemStack item = inv.getItemInSlot(slot);
 
                 if (!SlimefunUtils.isItemSimilar(item, produce.getInput()[0], true)
-                        || !Slimefun.getVirtualItemService()
+                        || !Slimefun.getItemStackService()
                                 .fits(
                                         inv.toInventory(),
                                         produce.getOutput()[0],

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractCraftingTable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractCraftingTable.java
@@ -4,8 +4,10 @@ import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ConsumeContext;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerBackpack;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.SlimefunBackpack;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.ThreadUtils;
@@ -48,7 +50,14 @@ abstract class AbstractCraftingTable extends MultiBlockMachine {
              */
             if (stack != null) {
                 stack = stack.clone();
-                ItemUtils.consumeItem(stack, true);
+
+                var consumed =
+                        Slimefun.getVirtualItemService().consume(stack, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
+                if (consumed.handled()) {
+                    stack = consumed.item();
+                } else {
+                    ItemUtils.consumeItem(stack, true);
+                }
             }
 
             fakeInv.setItem(j, stack);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractCraftingTable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractCraftingTable.java
@@ -51,8 +51,7 @@ abstract class AbstractCraftingTable extends MultiBlockMachine {
             if (stack != null) {
                 stack = stack.clone();
 
-                var consumed =
-                        Slimefun.getVirtualItemService().consume(stack, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
+                var consumed = Slimefun.getItemStackService().consume(stack, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
                 if (consumed.handled()) {
                     stack = consumed.item();
                 } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -97,7 +97,7 @@ public class ArmorForge extends AbstractCraftingTable {
 
                 if (item != null && item.getType() != Material.AIR) {
                     var consumed =
-                            Slimefun.getVirtualItemService().consume(item, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
+                            Slimefun.getItemStackService().consume(item, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
                     if (consumed.handled()) {
                         inv.setItem(j, consumed.item());
                     } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -5,6 +5,7 @@ import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ConsumeContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.services.sounds.SoundEffect;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -95,7 +96,13 @@ public class ArmorForge extends AbstractCraftingTable {
                 ItemStack item = inv.getContents()[j];
 
                 if (item != null && item.getType() != Material.AIR) {
-                    ItemUtils.consumeItem(item, true);
+                    var consumed =
+                            Slimefun.getVirtualItemService().consume(item, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
+                    if (consumed.handled()) {
+                        inv.setItem(j, consumed.item());
+                    } else {
+                        ItemUtils.consumeItem(item, true);
+                    }
                 }
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
@@ -98,7 +98,7 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
 
         ItemStack finalOutput = event.getOutput();
         if (p.getGameMode() != GameMode.CREATIVE) {
-            var consumed = Slimefun.getVirtualItemService().consume(input, 1, false, ConsumeContext.VIRTUAL_CRAFTING);
+            var consumed = Slimefun.getItemStackService().consume(input, 1, false, ConsumeContext.VIRTUAL_CRAFTING);
             if (consumed.handled()) {
                 p.getInventory()
                         .setItemInMainHand(consumed.item() == null ? new ItemStack(Material.AIR) : consumed.item());
@@ -116,7 +116,7 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
                 Optional<Inventory> outputChest = OutputChest.findOutputChestFor(b.getRelative(BlockFace.DOWN), output);
 
                 if (outputChest.isPresent()) {
-                    Slimefun.getVirtualItemService()
+                    Slimefun.getItemStackService()
                             .addItem(outputChest.get(), finalOutput.clone(), InventoryContext.OUTPUT_CHEST);
                 } else {
                     b.getWorld().dropItemNaturally(b.getLocation(), finalOutput.clone());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
@@ -98,7 +98,7 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
 
         ItemStack finalOutput = event.getOutput();
         if (p.getGameMode() != GameMode.CREATIVE) {
-            var consumed = Slimefun.getVirtualItemService().consume(input, 1, false, ConsumeContext.MENU_CONSUME);
+            var consumed = Slimefun.getVirtualItemService().consume(input, 1, false, ConsumeContext.VIRTUAL_CRAFTING);
             if (consumed.handled()) {
                 p.getInventory()
                         .setItemInMainHand(consumed.item() == null ? new ItemStack(Material.AIR) : consumed.item());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
@@ -5,6 +5,8 @@ import io.github.bakedlibs.dough.scheduling.TaskQueue;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ConsumeContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.core.services.sounds.SoundEffect;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -96,7 +98,13 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
 
         ItemStack finalOutput = event.getOutput();
         if (p.getGameMode() != GameMode.CREATIVE) {
-            ItemUtils.consumeItem(input, false);
+            var consumed = Slimefun.getVirtualItemService().consume(input, 1, false, ConsumeContext.MENU_CONSUME);
+            if (consumed.handled()) {
+                p.getInventory()
+                        .setItemInMainHand(consumed.item() == null ? new ItemStack(Material.AIR) : consumed.item());
+            } else {
+                ItemUtils.consumeItem(input, false);
+            }
         }
 
         TaskQueue queue = new TaskQueue();
@@ -108,7 +116,8 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
                 Optional<Inventory> outputChest = OutputChest.findOutputChestFor(b.getRelative(BlockFace.DOWN), output);
 
                 if (outputChest.isPresent()) {
-                    outputChest.get().addItem(finalOutput.clone());
+                    Slimefun.getVirtualItemService()
+                            .addItem(outputChest.get(), finalOutput.clone(), InventoryContext.OUTPUT_CHEST);
                 } else {
                     b.getWorld().dropItemNaturally(b.getLocation(), finalOutput.clone());
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
@@ -97,7 +97,7 @@ public class EnhancedCraftingTable extends AbstractCraftingTable {
 
                 if (item != null && item.getType() != Material.AIR) {
                     var consumed =
-                            Slimefun.getVirtualItemService().consume(item, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
+                            Slimefun.getItemStackService().consume(item, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
                     if (consumed.handled()) {
                         inv.setItem(j, consumed.item());
                     } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
@@ -5,6 +5,7 @@ import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ConsumeContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.services.sounds.SoundEffect;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -95,7 +96,13 @@ public class EnhancedCraftingTable extends AbstractCraftingTable {
                 ItemStack item = inv.getContents()[j];
 
                 if (item != null && item.getType() != Material.AIR) {
-                    ItemUtils.consumeItem(item, true);
+                    var consumed =
+                            Slimefun.getVirtualItemService().consume(item, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
+                    if (consumed.handled()) {
+                        inv.setItem(j, consumed.item());
+                    } else {
+                        ItemUtils.consumeItem(item, true);
+                    }
                 }
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
@@ -88,7 +88,7 @@ public class EnhancedCraftingTable extends AbstractCraftingTable {
             if (sfItem instanceof SlimefunBackpack backpack) {
                 waitCallback = upgradeBackpack(p, inv, backpack, output, () -> {
                     SoundEffect.ENHANCED_CRAFTING_TABLE_CRAFT_SOUND.playAt(b);
-                    outputInv.addItem(output);
+                    handleCraftedItem(output, dispenser, inv);
                 });
             }
 
@@ -108,7 +108,7 @@ public class EnhancedCraftingTable extends AbstractCraftingTable {
 
             if (!waitCallback) {
                 SoundEffect.ENHANCED_CRAFTING_TABLE_CRAFT_SOUND.playAt(b);
-                outputInv.addItem(output);
+                handleCraftedItem(output, dispenser, inv);
             }
         } else {
             Slimefun.getLocalization().sendMessage(p, "machines.full-inventory", true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -6,6 +6,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ConsumeContext;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.OutputChest;
@@ -135,7 +136,13 @@ public class TableSaw extends MultiBlockMachine {
         }
 
         if (p.getGameMode() != GameMode.CREATIVE) {
-            ItemUtils.consumeItem(item, true);
+            var consumed = Slimefun.getVirtualItemService().consume(item, 1, true, ConsumeContext.MENU_CONSUME);
+            if (consumed.handled()) {
+                p.getInventory()
+                        .setItemInMainHand(consumed.item() == null ? new ItemStack(Material.AIR) : consumed.item());
+            } else {
+                ItemUtils.consumeItem(item, true);
+            }
         }
 
         outputItems(b, event.getOutput());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -7,6 +7,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ConsumeContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.OutputChest;
@@ -169,7 +170,11 @@ public class TableSaw extends MultiBlockMachine {
         Optional<Inventory> outputChest = OutputChest.findOutputChestFor(b, output);
 
         if (outputChest.isPresent()) {
-            outputChest.get().addItem(output);
+            ItemStack rest =
+                    Slimefun.getVirtualItemService().addItem(outputChest.get(), output, InventoryContext.OUTPUT_CHEST);
+            if (rest != null) {
+                b.getWorld().dropItemNaturally(b.getLocation(), rest);
+            }
         } else {
             b.getWorld().dropItemNaturally(b.getLocation(), output);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -137,7 +137,7 @@ public class TableSaw extends MultiBlockMachine {
         }
 
         if (p.getGameMode() != GameMode.CREATIVE) {
-            var consumed = Slimefun.getVirtualItemService().consume(item, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
+            var consumed = Slimefun.getItemStackService().consume(item, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
             if (consumed.handled()) {
                 p.getInventory()
                         .setItemInMainHand(consumed.item() == null ? new ItemStack(Material.AIR) : consumed.item());
@@ -171,7 +171,7 @@ public class TableSaw extends MultiBlockMachine {
 
         if (outputChest.isPresent()) {
             ItemStack rest =
-                    Slimefun.getVirtualItemService().addItem(outputChest.get(), output, InventoryContext.OUTPUT_CHEST);
+                    Slimefun.getItemStackService().addItem(outputChest.get(), output, InventoryContext.OUTPUT_CHEST);
             if (rest != null) {
                 b.getWorld().dropItemNaturally(b.getLocation(), rest);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -137,7 +137,7 @@ public class TableSaw extends MultiBlockMachine {
         }
 
         if (p.getGameMode() != GameMode.CREATIVE) {
-            var consumed = Slimefun.getVirtualItemService().consume(item, 1, true, ConsumeContext.MENU_CONSUME);
+            var consumed = Slimefun.getVirtualItemService().consume(item, 1, true, ConsumeContext.VIRTUAL_CRAFTING);
             if (consumed.handled()) {
                 p.getInventory()
                         .setItemInMainHand(consumed.item() == null ? new ItemStack(Material.AIR) : consumed.item());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
@@ -279,8 +279,8 @@ class MiningTask implements Runnable {
                 if (state instanceof Chest chestState) {
                     Inventory inv = chestState.getBlockInventory();
 
-                    if (Slimefun.getVirtualItemService().fits(inv, item, InventoryContext.OUTPUT_CHEST)) {
-                        Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.OUTPUT_CHEST);
+                    if (Slimefun.getItemStackService().fits(inv, item, InventoryContext.OUTPUT_CHEST)) {
+                        Slimefun.getItemStackService().addItem(inv, item, InventoryContext.OUTPUT_CHEST);
                         return true;
                     } else {
                         stop(MinerStoppingReason.CHEST_FULL);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
@@ -1,10 +1,10 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.multiblocks.miner;
 
 import io.github.bakedlibs.dough.blocks.BlockPosition;
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.bakedlibs.dough.scheduling.TaskQueue;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
 import io.github.thebusybiscuit.slimefun4.core.services.sounds.SoundEffect;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedParticle;
@@ -279,8 +279,8 @@ class MiningTask implements Runnable {
                 if (state instanceof Chest chestState) {
                     Inventory inv = chestState.getBlockInventory();
 
-                    if (InvUtils.fits(inv, item)) {
-                        inv.addItem(item);
+                    if (Slimefun.getVirtualItemService().fits(inv, item, InventoryContext.OUTPUT_CHEST)) {
+                        Slimefun.getVirtualItemService().addItem(inv, item, InventoryContext.OUTPUT_CHEST);
                         return true;
                     } else {
                         stop(MinerStoppingReason.CHEST_FULL);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -11,6 +11,8 @@ import io.github.thebusybiscuit.slimefun4.api.exceptions.PrematureCodeException;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSpawnReason;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ComparisonResult;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.MatchContext;
 import io.github.thebusybiscuit.slimefun4.core.attributes.DistinctiveItem;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactive;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Soulbound;
@@ -292,6 +294,31 @@ public final class SlimefunUtils {
     }
 
     public static boolean isItemSimilar(
+            @Nullable ItemStack item,
+            @Nullable ItemStack sfitem,
+            boolean checkLore,
+            boolean checkAmount,
+            boolean checkDistinctiveItem,
+            boolean checkCustomModelData) {
+        ComparisonResult comparison = Slimefun.getVirtualItemService().matches(item, sfitem, MatchContext.GENERIC);
+        if (comparison == ComparisonResult.MATCH) {
+            return true;
+        }
+
+        if (comparison == ComparisonResult.NO_MATCH) {
+            return false;
+        }
+
+        return isItemSimilarWithoutVirtualItems(
+                item, sfitem, checkLore, checkAmount, checkDistinctiveItem, checkCustomModelData);
+    }
+
+    public static boolean isItemSimilarWithoutVirtualItems(
+            @Nullable ItemStack item, @Nullable ItemStack sfitem, boolean checkLore, boolean checkAmount) {
+        return isItemSimilarWithoutVirtualItems(item, sfitem, checkLore, checkAmount, true, true);
+    }
+
+    public static boolean isItemSimilarWithoutVirtualItems(
             @Nullable ItemStack item,
             @Nullable ItemStack sfitem,
             boolean checkLore,

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -300,7 +300,7 @@ public final class SlimefunUtils {
             boolean checkAmount,
             boolean checkDistinctiveItem,
             boolean checkCustomModelData) {
-        ComparisonResult comparison = Slimefun.getVirtualItemService().matches(item, sfitem, MatchContext.GENERIC);
+        ComparisonResult comparison = Slimefun.getItemStackService().matches(item, sfitem, MatchContext.GENERIC);
         if (comparison == ComparisonResult.MATCH) {
             return true;
         }

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -441,7 +441,7 @@ public abstract class AContainer extends SlimefunItem
         for (MachineRecipe recipe : recipes) {
             for (ItemStack input : recipe.getInput()) {
                 for (int slot : getInputSlots()) {
-                    if (Slimefun.getVirtualItemService()
+                    if (Slimefun.getItemStackService()
                             .isSimilar(inventory.get(slot), input, MatchContext.RECIPE_INPUT, true, true)) {
                         found.put(slot, input.getAmount());
                         break;
@@ -450,7 +450,7 @@ public abstract class AContainer extends SlimefunItem
             }
 
             if (found.size() == recipe.getInput().length) {
-                if (!Slimefun.getVirtualItemService()
+                if (!Slimefun.getItemStackService()
                         .fitAll(
                                 inv.toInventory(),
                                 recipe.getOutput(),

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -2,23 +2,24 @@ package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.MatchContext;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
 import io.github.thebusybiscuit.slimefun4.core.attributes.MachineProcessHolder;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineProcessor;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNetComponentType;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.handlers.SimpleBlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.operations.CraftingOperation;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -440,7 +441,8 @@ public abstract class AContainer extends SlimefunItem
         for (MachineRecipe recipe : recipes) {
             for (ItemStack input : recipe.getInput()) {
                 for (int slot : getInputSlots()) {
-                    if (SlimefunUtils.isItemSimilar(inventory.get(slot), input, true)) {
+                    if (Slimefun.getVirtualItemService()
+                            .isSimilar(inventory.get(slot), input, MatchContext.RECIPE_INPUT, true, true)) {
                         found.put(slot, input.getAmount());
                         break;
                     }
@@ -448,7 +450,12 @@ public abstract class AContainer extends SlimefunItem
             }
 
             if (found.size() == recipe.getInput().length) {
-                if (!InvUtils.fitAll(inv.toInventory(), recipe.getOutput(), getOutputSlots())) {
+                if (!Slimefun.getVirtualItemService()
+                        .fitAll(
+                                inv.toInventory(),
+                                recipe.getOutput(),
+                                InventoryContext.MACHINE_OUTPUT,
+                                getOutputSlots())) {
                     return null;
                 }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
@@ -1,10 +1,14 @@
 package me.mrCookieSlime.Slimefun.api.inventory;
 
 import city.norain.slimefun4.utils.InventoryUtil;
-import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ComparisonResult;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.ConsumeContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.InventoryContext;
+import io.github.thebusybiscuit.slimefun4.api.items.virtual.VirtualItemHandler.MatchContext;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import javax.annotation.Nonnull;
@@ -76,7 +80,8 @@ public class DirtyChestMenu extends ChestMenu {
     }
 
     public boolean fits(@Nonnull ItemStack item, int... slots) {
-        var isSfItem = SlimefunItem.getByItem(item) != null;
+        var virtualItems = Slimefun.getVirtualItemService();
+        var isSfItem = SlimefunItem.getByItem(item) != null || virtualItems.isVirtualItem(item);
         var wrapper = ItemStackWrapper.wrap(item);
         var remain = item.getAmount();
 
@@ -84,17 +89,41 @@ public class DirtyChestMenu extends ChestMenu {
             // A small optimization for empty slots
             var slotItem = getItemInSlot(slot);
             if (slotItem == null || slotItem.getType().isAir()) {
-                return true;
-            }
-
-            if (isSfItem) {
-                if (!slotItem.hasItemMeta()
-                        || item.getType() != slotItem.getType()
-                        || !SlimefunUtils.isItemSimilar(slotItem, wrapper, true, false)) {
+                if (!virtualItems.canInsertIntoEmptySlot(item, InventoryContext.MENU_FIT)) {
                     continue;
                 }
 
-                var slotRemain = slotItem.getMaxStackSize() - slotItem.getAmount();
+                int maxStackSize = Math.min(
+                        virtualItems.getMaxStackSize(item, InventoryContext.MENU_FIT, item.getMaxStackSize()),
+                        toInventory().getMaxStackSize());
+                remain -= maxStackSize;
+
+                if (remain <= 0) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (isSfItem) {
+                if (!slotItem.hasItemMeta()) {
+                    continue;
+                }
+
+                ComparisonResult comparison = virtualItems.matches(slotItem, item, MatchContext.STACK_MERGE);
+                if (comparison == ComparisonResult.NO_MATCH) {
+                    continue;
+                }
+
+                if (comparison == ComparisonResult.NOT_HANDLED
+                        && (!SlimefunUtils.isItemSimilarWithoutVirtualItems(slotItem, wrapper, true, false))) {
+                    continue;
+                }
+
+                int maxStackSize = Math.min(
+                        virtualItems.getMaxStackSize(slotItem, InventoryContext.MENU_FIT, slotItem.getMaxStackSize()),
+                        toInventory().getMaxStackSize());
+                var slotRemain = maxStackSize - slotItem.getAmount();
 
                 remain -= slotRemain;
 
@@ -107,7 +136,7 @@ public class DirtyChestMenu extends ChestMenu {
         boolean result = false;
 
         if (!isSfItem) {
-            result = InvUtils.fits(toInventory(), wrapper, slots);
+            result = virtualItems.fits(toInventory(), item, InventoryContext.MENU_FIT, slots);
         }
 
         return result;
@@ -135,6 +164,7 @@ public class DirtyChestMenu extends ChestMenu {
 
         ItemStackWrapper wrapper = null;
         int amount = item.getAmount();
+        var virtualItems = Slimefun.getVirtualItemService();
 
         for (int slot : slots) {
             if (amount <= 0) {
@@ -143,32 +173,47 @@ public class DirtyChestMenu extends ChestMenu {
 
             ItemStack stack = getItemInSlot(slot);
 
-            if (stack == null) {
-                replaceExistingItem(slot, item);
-                return null;
+            if (stack == null || stack.getType().isAir()) {
+                if (!virtualItems.canInsertIntoEmptySlot(item, InventoryContext.MENU_INSERT)) {
+                    continue;
+                }
+
+                int maxStackSize = Math.min(
+                        virtualItems.getMaxStackSize(item, InventoryContext.MENU_INSERT, item.getMaxStackSize()),
+                        toInventory().getMaxStackSize());
+                int movedAmount = Math.min(amount, maxStackSize);
+
+                ItemStack inserted = item.clone();
+                inserted.setAmount(movedAmount);
+                replaceExistingItem(slot, inserted);
+                amount -= movedAmount;
             } else {
-                int maxStackSize =
-                        Math.min(stack.getMaxStackSize(), toInventory().getMaxStackSize());
+                int maxStackSize = Math.min(
+                        virtualItems.getMaxStackSize(stack, InventoryContext.MENU_INSERT, stack.getMaxStackSize()),
+                        toInventory().getMaxStackSize());
                 if (stack.getAmount() < maxStackSize) {
                     if (wrapper == null) {
                         wrapper = ItemStackWrapper.wrap(item);
                     }
 
-                    if (SlimefunItem.getByItem(item) != null) {
-                        // Patch: use sf item check
-                        if (!SlimefunUtils.isItemSimilar(stack, wrapper, true, false)) {
+                    ComparisonResult comparison = virtualItems.matches(stack, item, MatchContext.STACK_MERGE);
+                    if (comparison == ComparisonResult.NO_MATCH) {
+                        continue;
+                    }
+
+                    if (comparison == ComparisonResult.NOT_HANDLED && SlimefunItem.getByItem(item) != null) {
+                        if (!SlimefunUtils.isItemSimilarWithoutVirtualItems(stack, wrapper, true, false)) {
                             continue;
                         }
-                    } else {
-                        // Use original check
+                    } else if (comparison == ComparisonResult.NOT_HANDLED) {
                         if (!ItemUtils.canStack(wrapper, stack)) {
                             continue;
                         }
                     }
 
-                    amount -= (maxStackSize - stack.getAmount());
-                    stack.setAmount(Math.min(stack.getAmount() + item.getAmount(), maxStackSize));
-                    item.setAmount(amount);
+                    int movedAmount = Math.min(amount, maxStackSize - stack.getAmount());
+                    amount -= movedAmount;
+                    stack.setAmount(stack.getAmount() + movedAmount);
                 }
             }
         }
@@ -197,7 +242,15 @@ public class DirtyChestMenu extends ChestMenu {
             throw new IllegalStateException("Cannot consume item when menu is locked");
         }
 
-        ItemUtils.consumeItem(getItemInSlot(slot), amount, replaceConsumables);
+        ItemStack item = getItemInSlot(slot);
+        var virtualItems = Slimefun.getVirtualItemService();
+        var result = virtualItems.consume(item, amount, replaceConsumables, ConsumeContext.MENU_CONSUME);
+        if (result.handled()) {
+            replaceExistingItem(slot, result.item());
+        } else {
+            ItemUtils.consumeItem(item, amount, replaceConsumables);
+        }
+
         markDirty();
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
@@ -106,18 +106,18 @@ public class DirtyChestMenu extends ChestMenu {
             }
 
             if (isSfItem) {
-                if (!slotItem.hasItemMeta()) {
-                    continue;
-                }
-
                 ComparisonResult comparison = virtualItems.matches(slotItem, item, MatchContext.STACK_MERGE);
                 if (comparison == ComparisonResult.NO_MATCH) {
                     continue;
                 }
 
-                if (comparison == ComparisonResult.NOT_HANDLED
-                        && (!SlimefunUtils.isItemSimilarWithoutVirtualItems(slotItem, wrapper, true, false))) {
-                    continue;
+                if (comparison == ComparisonResult.NOT_HANDLED) {
+                    if (!slotItem.hasItemMeta()) {
+                        continue;
+                    }
+                    if (!SlimefunUtils.isItemSimilarWithoutVirtualItems(slotItem, wrapper, true, false)) {
+                        continue;
+                    }
                 }
 
                 int maxStackSize = Math.min(

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
@@ -80,7 +80,7 @@ public class DirtyChestMenu extends ChestMenu {
     }
 
     public boolean fits(@Nonnull ItemStack item, int... slots) {
-        var virtualItems = Slimefun.getVirtualItemService();
+        var virtualItems = Slimefun.getItemStackService();
         var isSfItem = SlimefunItem.getByItem(item) != null || virtualItems.isVirtualItem(item);
 
         if (slots.length == 0) {
@@ -169,7 +169,7 @@ public class DirtyChestMenu extends ChestMenu {
 
         ItemStackWrapper wrapper = null;
         int amount = item.getAmount();
-        var virtualItems = Slimefun.getVirtualItemService();
+        var virtualItems = Slimefun.getItemStackService();
 
         for (int slot : slots) {
             if (amount <= 0) {
@@ -248,7 +248,7 @@ public class DirtyChestMenu extends ChestMenu {
         }
 
         ItemStack item = getItemInSlot(slot);
-        var virtualItems = Slimefun.getVirtualItemService();
+        var virtualItems = Slimefun.getItemStackService();
         var result = virtualItems.consume(item, amount, replaceConsumables, ConsumeContext.MENU_CONSUME);
         if (result.handled()) {
             replaceExistingItem(slot, result.item());

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
@@ -123,7 +123,7 @@ public class DirtyChestMenu extends ChestMenu {
                 int maxStackSize = Math.min(
                         virtualItems.getMaxStackSize(slotItem, InventoryContext.MENU_FIT, slotItem.getMaxStackSize()),
                         toInventory().getMaxStackSize());
-                var slotRemain = maxStackSize - slotItem.getAmount();
+                var slotRemain = Math.max(0, maxStackSize - slotItem.getAmount());
 
                 remain -= slotRemain;
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
@@ -82,6 +82,11 @@ public class DirtyChestMenu extends ChestMenu {
     public boolean fits(@Nonnull ItemStack item, int... slots) {
         var virtualItems = Slimefun.getVirtualItemService();
         var isSfItem = SlimefunItem.getByItem(item) != null || virtualItems.isVirtualItem(item);
+
+        if (slots.length == 0) {
+            return virtualItems.fits(toInventory(), item, InventoryContext.MENU_FIT);
+        }
+
         var wrapper = ItemStackWrapper.wrap(item);
         var remain = item.getAmount();
 


### PR DESCRIPTION
<!-- 在做出贡献前, 请你先阅读我们的 [代码与 commit 规范](https://github.com/SlimefunGuguProject/Slimefun4/blob/master/CONTRIBUTING.md) -->

## 简介
<!-- 大致解释一下这个提交更改修复/优化/新增了什么 -->

## 概要

本 PR 引入了 **虚拟物品服务（Virtual Item Service）** — 一个轻量级、可选的 Hook 层，允许附属插件提供的"代理物品"（逻辑身份与其可见 `Material` 不同的物品）正确参与 Slimefun 的比较、堆叠、货运、配方、消费和输出流程。

## 新增 API

### `VirtualItemHandler`（接口，继承 `ItemHandler`）

**包路径：** `io.github.thebusybiscuit.slimefun4.api.items.virtual`

供附属插件实现虚拟物品逻辑的 SPI 接口。继承自 `ItemHandler`，通过标准的 `SlimefunItem.addItemHandler()` 注册到具体的 SlimefunItem 上。所有方法均有 `default` 实现并返回 `NOT_HANDLED`，确保完全向后兼容。

| 方法 | 用途 |
|------|------|
| `isVirtualItem(ItemStack)` | 轻量守卫 — 判断某个物品栈是否属于虚拟物品系统 |
| `matches(ItemStack, ItemStack, MatchContext)` | 三态比较（MATCH / NO_MATCH / NOT_HANDLED） |
| `matchesPredicate(ItemStack, Predicate, MatchContext)` | 与配方谓词比较（用于自动合成器） |
| `getMaxStackSize(ItemStack, InventoryContext, int)` | 覆盖有效最大堆叠数 |
| `allows(ItemStack, InventoryContext)` | 空槽插入的准入控制 |
| `consume(ItemStack, int, boolean, ConsumeContext)` | 自定义消费逻辑，带替换结果 |
| `getRemainder(ItemStack, RemainderContext)` | 自定义合成剩余物解析 |

#### 上下文枚举

| 枚举 | 值 | 用途 |
|------|------|------|
| `MatchContext` | `GENERIC`、`STACK_MERGE`、`RECIPE_INPUT`、`AUTO_CRAFTER_PREDICATE` | 区分比较意图 |
| `InventoryContext` | `MENU_FIT`、`MENU_INSERT`、`CARGO_INSERT`、`VANILLA_FIT`、`MACHINE_OUTPUT`、`OUTPUT_CHEST` | 区分插入上下文 |
| `ConsumeContext` | `MENU_CONSUME`、`VIRTUAL_CRAFTING` | 区分消费场景 |
| `RemainderContext` | `AUTO_CRAFTER`、`VIRTUAL_CRAFTING` | 区分剩余物场景 |

#### 返回值类型

| 类型 | 值 | 用途 |
|------|------|------|
| `ComparisonResult` | `NOT_HANDLED`、`MATCH`、`NO_MATCH` | 三态比较结果 |
| `AdmissionResult` | `NOT_HANDLED`、`ALLOW`、`DENY` | 三态准入结果 |
| `ItemResult` | `record(boolean handled, ItemStack item)` | 带处理标记的物品栈替换结果 |

### `VirtualItemService`（服务）

**包路径：** `io.github.thebusybiscuit.slimefun4.core.services`

统一访问入口，在 `Slimefun` 上注册为单例。Handler 的解析完全基于 `SlimefunItem`：通过 `SlimefunItem.getByItem()` 找到物品对应的 SlimefunItem，再从其 handler 列表中查找 `VirtualItemHandler`，最后调用 `isVirtualItem()` 确认。

#### 核心方法

| 方法 | 无 handler 时的回退行为 |
|------|------|
| `isVirtualItem(ItemStack)` | `false` |
| `matches(...)` | `NOT_HANDLED` → 调用方使用原逻辑 |
| `isSimilar(...)` | 回退到 `SlimefunUtils.isItemSimilarWithoutVirtualItems()` |
| `matchesPredicate(...)` | 仅执行 `predicate.test(item)` |
| `getMaxStackSize(...)` | 原样返回 `defaultMaxStackSize` |
| `canInsertIntoEmptySlot(...)` | `true`（始终允许） |
| `consume(...)` | `ItemResult.notHandled()` → 调用方使用 `ItemUtils.consumeItem()` |
| `getRemainder(...)` | `ItemResult.notHandled()` → 调用方使用原 switch 逻辑 |
| `fits(Inventory, ItemStack, ctx, slots...)` | `InvUtils.fits()` |
| `fitAll(Inventory, ItemStack[], ctx, slots...)` | `InvUtils.fitAll()` |
| `addItem(Inventory, ItemStack, ctx, slots...)` | `inventory.addItem()` |

**访问方式：** `Slimefun.getVirtualItemService()`

---

## 修改文件 — 按层分类

### 比较与堆叠层

| 文件 | 变更 |
|------|------|
| `SlimefunUtils.java` | `isItemSimilar()` 现在优先查询 `VirtualItemService.matches()`；新增 `isItemSimilarWithoutVirtualItems()` 作为绕过方法 |
| `DirtyChestMenu.java` | `fits()` — 虚拟物品准入、自定义最大堆叠数、三态合并检查；`pushItem()` — 同上；`consumeItem()` — 委托给 `VirtualItemService.consume()` |

### 货运层

| 文件 | 变更 |
|------|------|
| `CargoUtils.java` | `insertIntoBlockMenu()` 和 `insertIntoVanillaInventory()` — 空槽准入、自定义堆叠数、通过 `VirtualItemService` 进行三态比较 |
| `CargoNetworkTask.java` | `insertItem()` — 主插入和回退插入均使用 `VirtualItemService.addItem()` |

### 配方与机器层

| 文件 | 变更 |
|------|------|
| `AContainer.java` | `findNextRecipe()` — 使用 `isSimilar()` 进行输入匹配，`fitAll()` 进行输出检查 |
| `AbstractAutoCrafter.java` | `matches()` — 使用 `matchesPredicate()`；`getLeftoverItem()` — 优先查询 `getRemainder()` |
| `AbstractCraftingTable.java` | `createVirtualInventory()` — 消费逻辑委托给 `VirtualItemService.consume()` |
| `MultiBlockMachine.java` | `findOutputInventory()` — 使用 `fits()`；`handleCraftedItem()` — 使用 `addItem()` |

### 多方块机器

| 文件 | 变更 |
|------|------|
| `ArmorForge.java` | `craft()` 消费 → `VirtualItemService.consume()` |
| `EnhancedCraftingTable.java` | `craft()` 消费 → `VirtualItemService.consume()` |
| `TableSaw.java` | 手持物品消费 → `VirtualItemService.consume()` |
| `AutomatedPanningMachine.java` | 手持消费 + 输出 → `VirtualItemService.consume()` / `addItem()` |
| `MiningTask.java` | 输出 fits + addItem → `VirtualItemService.fits()` / `addItem()` |

### 电力机器

| 文件 | 变更 |
|------|------|
| `AutoBrewer.java` | 输出 fits → `VirtualItemService.fits()` |
| `AutoEnchanter.java` | 输出 fitAll → `VirtualItemService.fitAll()` |
| `AutoDisenchanter.java` | 输出 fitAll → `VirtualItemService.fitAll()` |
| `BookBinder.java` | 输出 fitAll → `VirtualItemService.fitAll()` |
| `ProduceCollector.java` | 输出 fits → `VirtualItemService.fits()` |

### 自动合成器解析器

| 文件 | 变更 |
|------|------|
| `ChestInventoryParser.java` | `canOutput()` / `addItem()` / `isFit()` → `VirtualItemService` |
| `CrafterSmartPortParser.java` | `canOutput()` → `VirtualItemService.fits()` |

### 输出

| 文件 | 变更 |
|------|------|
| `OutputChest.java` | `findOutputChestFor()` → `VirtualItemService.fits()` |

### 插件入口

| 文件 | 变更 |
|------|------|
| `Slimefun.java` | 新增 `VirtualItemService` 字段 + `getVirtualItemService()` 静态访问方法 |

---

## Addon开发者迁移指南

### 如果你不使用虚拟物品

**无需任何操作。** 当没有 `VirtualItemHandler` 时，所有行为完全不变。

### 如果你想提供虚拟物品 handler

在 SlimefunItem 注册前，使用标准的 `addItemHandler()` 方法：

```java
// 创建你的 SlimefunItem
SlimefunItem myItem = new SlimefunItem(group, item, recipeType, recipe);

// 在注册前添加 VirtualItemHandler
myItem.addItemHandler(new VirtualItemHandler() {
    @Override
    public boolean isVirtualItem(@Nullable ItemStack item) {
        // 判断此ItemStack是否属于你的虚拟物品系统
        return MyVirtualItemUtils.isMyVirtualItem(item);
    }

    @Override
    public @Nonnull ComparisonResult matches(
            @Nullable ItemStack left, @Nullable ItemStack right, @Nonnull MatchContext context) {
        // 自定义比较逻辑
        return ComparisonResult.NOT_HANDLED;
    }

    // 按需覆写其他方法...
});

// 注册
myItem.register(myAddon);
```

如果多个 SlimefunItem 共享同一套虚拟物品逻辑，可以复用同一个 handler 实例：

```java
VirtualItemHandler sharedHandler = new MyVirtualItemHandler();
myItem1.addItemHandler(sharedHandler);
myItem2.addItemHandler(sharedHandler);
```

> **注意：** `addItemHandler()` 只能在 SlimefunItem 注册前调用（即 `register()` 之前）。

### 如果你直接调用了 `InvUtils.fits()` / `InvUtils.fitAll()`

建议改用 `Slimefun.getVirtualItemService().fits()` / `.fitAll()` 以支持虚拟物品。当没有虚拟物品参与时，服务会自动回退到 `InvUtils`。

### 如果你直接调用了 `SlimefunUtils.isItemSimilar()`

无需改动 — 该方法现在内部会自动查询虚拟物品服务。如果你需要显式使用旧行为（绕过虚拟物品），请使用 `SlimefunUtils.isItemSimilarWithoutVirtualItems()`。

### 如果你在菜单槽位上直接调用了 `ItemUtils.consumeItem()`

建议改用 `Slimefun.getVirtualItemService().consume()` 并检查 `result.handled()`。未处理时回退到 `ItemUtils.consumeItem()`。

---

## 破坏性变更

**无。** 这是一个纯增量变更。所有新增 API 方法均有安全的默认值。现有附属插件无需任何修改即可正常编译和运行。


## 相关的 Issues (没有可不填)
<!-- 如果这个提交更改解决了 Issue 中的问题, 请手动标记对应的 Issues -->
<!-- 例如: "Fixes #000" -->
