### PR TITLE
Optimize universal block detection to avoid expensive NBT lookups

### DIFF
--- a/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/util/StorageCacheUtils.java
+++ b/src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/util/StorageCacheUtils.java
@@ -42,18 +42,21 @@ public class StorageCacheUtils {
 
     @ParametersAreNonnullByDefault
     public static boolean hasUniversalBlock(Location l) {
-        var uniDataByNBT = TaskUtil.runSyncMethod(() -> Slimefun.getBlockDataService()
-                .getUniversalDataUUID(l.getBlock())
-                .isPresent());
-
-        if (uniDataByNBT) {
+        if (Slimefun.getDatabaseManager()
+                .getBlockDataController()
+                .getUniversalBlockDataFromCache(l)
+                .isPresent()) {
             return true;
         }
 
-        return Slimefun.getDatabaseManager()
-                .getBlockDataController()
-                .getUniversalBlockDataFromCache(l)
-                .isPresent();
+        var block = l.getBlock();
+        if (!Slimefun.getBlockDataService().isTileEntity(block.getType())) {
+            return false;
+        }
+
+        return TaskUtil.runSyncMethod(() -> Slimefun.getBlockDataService()
+                .getUniversalDataUUID(block)
+                .isPresent());
     }
 
     @ParametersAreNonnullByDefault


### PR DESCRIPTION
### Motivation
- Reduce hot-path overhead observed in the Spark report where explosion/physics handling frequently invoked universal block checks. 
- Avoid synchronous NBT/PersistentData reads for blocks that cannot possibly hold universal data (non-tile-entities) to improve performance during bulk block operations.

### Description
- Updated `StorageCacheUtils.hasUniversalBlock(Location)` in `src/main/java/com/xzavier0722/mc/plugin/slimefun4/storage/util/StorageCacheUtils.java` to first check the in-memory universal block cache before any NBT lookup.  
- Added a tile-entity guard using `Slimefun.getBlockDataService().isTileEntity(...)` to immediately return `false` for non-tile blocks.  
- Deferred the expensive `getUniversalDataUUID` call behind `TaskUtil.runSyncMethod(...)` and only execute it when the block is a tile-entity and not present in the cache.

### Testing
- Ran `git diff --check` without issues.  
- Attempted `./gradlew compileJava` but the Gradle distribution download was blocked by the environment proxy (HTTP 403), so a full compile could not be completed.  
- `mvn -q -DskipTests compile` is not applicable because the repository uses Gradle and there is no top-level `pom.xml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b07e0d69c832fbefdcb3d4a8f13a6)