### PR TITLE
Tick freeze

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunTabCompleter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunTabCompleter.java
@@ -45,6 +45,8 @@ class SlimefunTabCompleter implements TabCompleter {
                         Bukkit.getWorlds().stream().map(WorldInfo::getName).toList());
                 list.add("*");
                 return createReturnList(list, args[1]);
+            } else if (args[0].equalsIgnoreCase("tick")) {
+                return createReturnList(List.of("at", "freeze", "query", "rate", "show", "unfreeze"), args[1]);
             }
             return null;
         } else if (args.length == 3) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
@@ -47,6 +47,7 @@ public final class SlimefunSubCommands {
         commands.add(new BanItemCommand(plugin, cmd));
         commands.add(new UnbanItemCommand(plugin, cmd));
         commands.add(new ClearDataCommand(plugin, cmd));
+        commands.add(new TickCommand(plugin, cmd));
         return commands;
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
@@ -1,0 +1,159 @@
+package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
+
+import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
+import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.block.Block;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * @author balugaq
+ */
+public class TickCommand extends SubCommand {
+    @ParametersAreNonnullByDefault
+    public TickCommand(Slimefun plugin, SlimefunCommand cmd) {
+        super(plugin, cmd, "tick", false);
+    }
+
+    @Override
+    public void onExecute(@Nonnull CommandSender sender, @Nonnull String[] args) {
+        if (sender.hasPermission("slimefun.command.tick") || sender instanceof ConsoleCommandSender) {
+            if (args.length == 1) {
+                Slimefun.getTickerTask().setTickFreeze(!Slimefun.getTickerTask().isTickFreeze());
+                Slimefun.getLocalization()
+                        .sendMessage(
+                                sender,
+                                "messages.tick-mode",
+                                true,
+                                msg -> msg.replace(
+                                        "%mode%", Slimefun.getTickerTask().isTickFreeze() ? "开启" : "关闭"));
+                return;
+            }
+
+            if (args.length == 2) {
+                if (sender instanceof Player player && args[1].equalsIgnoreCase("at")) {
+                    Block b = player.getTargetBlockExact(8, FluidCollisionMode.NEVER);
+                    SlimefunItem sf = null;
+                    if (b != null) {
+                        sf = StorageCacheUtils.getSlimefunItem(b.getLocation());
+                    }
+
+                    if (sf == null) {
+                        sf = SlimefunItem.getByItem(player.getInventory().getItemInMainHand());
+                    }
+
+                    if (sf == null) {
+                        Slimefun.getLocalization().sendMessage(sender, "messages.not-found", true);
+                        return;
+                    }
+
+                    final SlimefunItem finalSf = sf;
+                    Slimefun.getTickerTask()
+                            .setTickFreezePredicate(
+                                    entry -> entry.getItem().getId().equals(finalSf.getId()));
+
+                    return;
+                } else if (args[1].equalsIgnoreCase("show")) {
+                    Slimefun.getTickerTask().showWaitingList();
+                    return;
+                } else if (args[1].equalsIgnoreCase("freeze")) {
+                    Slimefun.getTickerTask().setTickFreeze(true);
+                    Slimefun.getLocalization()
+                            .sendMessage(sender, "messages.tick-mode", true, msg -> msg.replace("%mode%", "开启"));
+                    return;
+                } else if (args[1].equalsIgnoreCase("unfreeze")) {
+                    Slimefun.getTickerTask().setTickFreeze(false);
+                    Slimefun.getLocalization()
+                            .sendMessage(sender, "messages.tick-mode", true, msg -> msg.replace("%mode%", "关闭"));
+                    return;
+                } else if (args[1].equalsIgnoreCase("query")) {
+                    Slimefun.getLocalization()
+                            .sendMessage(
+                                    sender,
+                                    "messages.tick-query",
+                                    true,
+                                    msg -> msg.replace(
+                                                    "%mode%",
+                                                    Slimefun.getTickerTask().isTickFreeze() ? "开启" : "关闭")
+                                            .replace(
+                                                    "%tick-rate%",
+                                                    ""
+                                                            + Slimefun.getTickerTask()
+                                                                    .getTickRate()));
+                    return;
+                } else {
+                    SlimefunItem item = SlimefunItem.getById(args[1].toUpperCase());
+                    if (item != null) {
+                        Slimefun.getTickerTask()
+                                .setTickFreezePredicate(entry -> entry.getItem().equals(item));
+                    } else {
+                        Slimefun.getLocalization().sendMessage(sender, "messages.not-found");
+                    }
+                    return;
+                }
+            }
+
+            if (args[1].equalsIgnoreCase("rate") && args.length == 3) {
+                try {
+                    int rate = Integer.parseInt(args[2]);
+                    Slimefun.getTickerTask().setTickRate(rate);
+                    Slimefun.getLocalization()
+                            .sendMessage(
+                                    sender,
+                                    "messages.tick-rate",
+                                    true,
+                                    msg -> msg.replace("%tick-rate%", String.valueOf(rate)));
+                } catch (NumberFormatException e) {
+                    Slimefun.getLocalization().sendMessage(sender, "messages.not-a-number", true);
+                }
+                return;
+            }
+
+            if (args.length >= 4) {
+                int offset = 0;
+                if (args.length == 5) {
+                    offset = 1;
+                }
+                String worldname = args.length == 5
+                        ? args[1]
+                        : (sender instanceof Player p ? p.getWorld().getName() : "world");
+                try {
+                    int x = Integer.parseInt(args[1 + offset]);
+                    int y = Integer.parseInt(args[2 + offset]);
+                    int z = Integer.parseInt(args[3 + offset]);
+                    Slimefun.getTickerTask().setTickFreezePredicate(entry -> {
+                        var l = entry.getLocation();
+                        return l.getWorld().getName().equals(worldname)
+                                && l.getBlockX() == x
+                                && l.getBlockY() == y
+                                && l.getBlockZ() == z;
+                    });
+                } catch (NumberFormatException e) {
+                    Slimefun.getLocalization().sendMessage(sender, "messages.not-a-number", true);
+                }
+
+                Slimefun.getLocalization()
+                        .sendMessage(
+                                sender,
+                                "messages.usage",
+                                true,
+                                msg -> msg.replace("%usage%", "/sf tick (<x> <y> <z> | <Slimefun Item>)"));
+            }
+        } else {
+            Slimefun.getLocalization().sendMessage(sender, "messages.no-permission", true);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public String getDescription() {
+        return "commands.tick.description";
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
@@ -81,12 +81,24 @@ public class TickCommand extends SubCommand {
                 } else if (args[1].equalsIgnoreCase("freeze")) {
                     Slimefun.getTickerTask().setTickFreeze(true);
                     Slimefun.getLocalization()
-                            .sendMessage(sender, "messages.tick-mode", true, msg -> msg.replace("%mode%", "开启"));
+                            .sendMessage(
+                                    sender,
+                                    "messages.tick-mode",
+                                    true,
+                                    msg -> msg.replace(
+                                            "%mode%",
+                                            Slimefun.getLocalization().getMessage("messages.tick-freeze-on")));
                     return;
                 } else if (args[1].equalsIgnoreCase("unfreeze")) {
                     Slimefun.getTickerTask().setTickFreeze(false);
                     Slimefun.getLocalization()
-                            .sendMessage(sender, "messages.tick-mode", true, msg -> msg.replace("%mode%", "关闭"));
+                            .sendMessage(
+                                    sender,
+                                    "messages.tick-mode",
+                                    true,
+                                    msg -> msg.replace(
+                                            "%mode%",
+                                            Slimefun.getLocalization().getMessage("messages.tick-freeze-off")));
                     return;
                 } else if (args[1].equalsIgnoreCase("query")) {
                     Slimefun.getLocalization()
@@ -96,7 +108,11 @@ public class TickCommand extends SubCommand {
                                     true,
                                     msg -> msg.replace(
                                                     "%mode%",
-                                                    Slimefun.getTickerTask().isTickFreeze() ? "开启" : "关闭")
+                                                    Slimefun.getTickerTask().isTickFreeze()
+                                                            ? Slimefun.getLocalization()
+                                                                    .getMessage("messages.tick-freeze-on")
+                                                            : Slimefun.getLocalization()
+                                                                    .getMessage("messages.tick-freeze-off"))
                                             .replace(
                                                     "%tick-rate%",
                                                     ""

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
@@ -5,6 +5,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
 import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.bukkit.FluidCollisionMode;
@@ -12,8 +13,6 @@ import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
-
-import java.util.Locale;
 
 /**
  * @author balugaq

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
@@ -33,32 +33,46 @@ public class TickCommand extends SubCommand {
                                 "messages.tick-mode",
                                 true,
                                 msg -> msg.replace(
-                                        "%mode%", Slimefun.getTickerTask().isTickFreeze() ? "开启" : "关闭"));
+                                        "%mode%",
+                                        Slimefun.getTickerTask().isTickFreeze()
+                                                ? Slimefun.getLocalization().getMessage("messages.tick-freeze-on")
+                                                : Slimefun.getLocalization().getMessage("messages.tick-freeze-off")));
                 return;
             }
 
             if (args.length == 2) {
                 if (sender instanceof Player player && args[1].equalsIgnoreCase("at")) {
                     Block b = player.getTargetBlockExact(8, FluidCollisionMode.NEVER);
-                    SlimefunItem sf = null;
                     if (b != null) {
-                        sf = StorageCacheUtils.getSlimefunItem(b.getLocation());
+                        SlimefunItem sf = StorageCacheUtils.getSlimefunItem(b.getLocation());
+                        if (sf != null) {
+                            Slimefun.getTickerTask().setTickFreezePredicate(entry -> {
+                                var l = entry.getLocation();
+                                return l.getWorld()
+                                                .getName()
+                                                .equals(b.getLocation()
+                                                        .getWorld()
+                                                        .getName())
+                                        && l.getBlockX() == b.getLocation().getBlockX()
+                                        && l.getBlockY() == b.getLocation().getBlockY()
+                                        && l.getBlockZ() == b.getLocation().getBlockZ();
+                            });
+                            return;
+                        }
                     }
 
-                    if (sf == null) {
-                        sf = SlimefunItem.getByItem(player.getInventory().getItemInMainHand());
-                    }
-
-                    if (sf == null) {
-                        Slimefun.getLocalization().sendMessage(sender, "messages.not-found", true);
+                    SlimefunItem sf =
+                            SlimefunItem.getByItem(player.getInventory().getItemInMainHand());
+                    if (sf != null) {
+                        Slimefun.getTickerTask()
+                                .setTickFreezePredicate(
+                                        entry -> entry.getItem().getId().equals(sf.getId()));
                         return;
                     }
 
-                    final SlimefunItem finalSf = sf;
-                    Slimefun.getTickerTask()
-                            .setTickFreezePredicate(
-                                    entry -> entry.getItem().getId().equals(finalSf.getId()));
+                    Slimefun.getTickerTask().setTickFreezePredicate(entry -> false);
 
+                    Slimefun.getLocalization().sendMessage(sender, "messages.tick-freeze-predicate-reset", true);
                     return;
                 } else if (args[1].equalsIgnoreCase("show")) {
                     Slimefun.getTickerTask().showWaitingList();
@@ -135,17 +149,19 @@ public class TickCommand extends SubCommand {
                                 && l.getBlockY() == y
                                 && l.getBlockZ() == z;
                     });
+                    return;
                 } catch (NumberFormatException e) {
                     Slimefun.getLocalization().sendMessage(sender, "messages.not-a-number", true);
+                    return;
                 }
-
-                Slimefun.getLocalization()
-                        .sendMessage(
-                                sender,
-                                "messages.usage",
-                                true,
-                                msg -> msg.replace("%usage%", "/sf tick (<x> <y> <z> | <Slimefun Item>)"));
             }
+
+            Slimefun.getLocalization()
+                    .sendMessage(
+                            sender,
+                            "messages.usage",
+                            true,
+                            msg -> msg.replace("%usage%", "/sf tick (<x> <y> <z> | <Slimefun Item>)"));
         } else {
             Slimefun.getLocalization().sendMessage(sender, "messages.no-permission", true);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TickCommand.java
@@ -13,6 +13,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
+import java.util.Locale;
+
 /**
  * @author balugaq
  */
@@ -103,7 +105,7 @@ public class TickCommand extends SubCommand {
                                                                     .getTickRate()));
                     return;
                 } else {
-                    SlimefunItem item = SlimefunItem.getById(args[1].toUpperCase());
+                    SlimefunItem item = SlimefunItem.getById(args[1].toUpperCase(Locale.ROOT));
                     if (item != null) {
                         Slimefun.getTickerTask()
                                 .setTickFreezePredicate(entry -> entry.getItem().equals(item));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -11,22 +11,37 @@ import io.github.thebusybiscuit.slimefun4.api.ErrorReport;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.ticker.TickLocation;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.utils.ParticleUtil;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
 import lombok.Setter;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.TextColor;
 import org.apache.commons.lang.Validate;
+import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitScheduler;
 
 /**
@@ -38,6 +53,7 @@ import org.bukkit.scheduler.BukkitScheduler;
  * @see BlockTicker
  *
  */
+@Getter
 public class TickerTask implements Runnable {
 
     /**
@@ -52,12 +68,36 @@ public class TickerTask implements Runnable {
      */
     private final Map<BlockPosition, Integer> bugs = new ConcurrentHashMap<>();
 
+    private int count = 0;
+
+    @Setter
     private int tickRate;
+
     private boolean halted = false;
     private boolean running = false;
 
     @Setter
     private volatile boolean paused = false;
+
+    private Deque<WaitingEntry> waiting = new ArrayDeque<>(256);
+
+    private final int PAGE_SIZE = 10;
+
+    @Setter
+    private boolean tickFreeze = false;
+
+    @Setter
+    private Predicate<WaitingEntry> tickFreezePredicate = entry -> false;
+
+    @Data
+    @AllArgsConstructor
+    public static class WaitingEntry {
+        private Location location;
+        private SlimefunItem item;
+        private ASlimefunDataContainer data;
+        private long timestamp;
+        private boolean sync;
+    }
 
     /**
      * This method starts the {@link TickerTask} on an asynchronous schedule.
@@ -69,7 +109,7 @@ public class TickerTask implements Runnable {
         this.tickRate = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
 
         BukkitScheduler scheduler = plugin.getServer().getScheduler();
-        scheduler.runTaskTimerAsynchronously(plugin, this, 100L, tickRate);
+        scheduler.runTaskTimerAsynchronously(plugin, this, 100L, 1);
     }
 
     /**
@@ -83,6 +123,21 @@ public class TickerTask implements Runnable {
     public void run() {
         if (paused) {
             return;
+        }
+
+        if (tickFreeze && !waiting.isEmpty()) {
+            return;
+        }
+
+        count += 1;
+        if (count < tickRate) {
+            return;
+        }
+        count = 0;
+
+        int length = waiting.size();
+        for (int i = 0; i < length; i++) {
+            tickBlock();
         }
 
         try {
@@ -115,6 +170,9 @@ public class TickerTask implements Runnable {
 
             reset();
             Slimefun.getProfiler().stop();
+            if (tickFreeze) {
+                showWaitingList();
+            }
         } catch (Exception | LinkageError x) {
             Slimefun.logger()
                     .log(
@@ -163,20 +221,11 @@ public class TickerTask implements Runnable {
                     Slimefun.getProfiler().scheduleEntries(1);
                     item.getBlockTicker().update();
 
-                    /**
-                     * We are inserting a new timestamp because synchronized actions
-                     * are always ran with a 50ms delay (1 game tick)
-                     */
-                    Slimefun.runSync(() -> {
-                        if (blockData.isPendingRemove()) {
-                            return;
-                        }
-                        tickBlock(l, item, blockData, System.nanoTime());
-                    });
+                    tickBlock(l, item, blockData, System.nanoTime(), true);
                 } else {
                     long timestamp = Slimefun.getProfiler().newEntry();
                     item.getBlockTicker().update();
-                    tickBlock(l, item, blockData, timestamp);
+                    tickBlock(l, item, blockData, timestamp, false);
                 }
 
                 tickers.add(item.getBlockTicker());
@@ -209,12 +258,12 @@ public class TickerTask implements Runnable {
                         if (data.isPendingRemove()) {
                             return;
                         }
-                        tickBlock(l, item, data, System.nanoTime());
+                        tickBlock(l, item, data, System.nanoTime(), true);
                     });
                 } else {
                     long timestamp = Slimefun.getProfiler().newEntry();
                     item.getBlockTicker().update();
-                    tickBlock(l, item, data, timestamp);
+                    tickBlock(l, item, data, timestamp, false);
                 }
 
                 tickers.add(item.getBlockTicker());
@@ -226,20 +275,67 @@ public class TickerTask implements Runnable {
 
     @ParametersAreNonnullByDefault
     private void tickBlock(Location l, SlimefunItem item, ASlimefunDataContainer data, long timestamp) {
+        tickBlock(l, item, data, timestamp, true); // fallback
+    }
+
+    @ParametersAreNonnullByDefault
+    private void tickBlock(Location l, SlimefunItem item, ASlimefunDataContainer data, long timestamp, boolean sync) {
+        var entry = new WaitingEntry(l, item, data, timestamp, sync);
+        waiting.add(entry);
+        if (tickFreezePredicate.test(entry)) {
+            tickFreeze = true;
+        }
+        if (!tickFreeze) {
+            tickBlock();
+        }
+    }
+
+    private void tickBlock() {
+        WaitingEntry entry = waiting.poll();
+        if (entry == null) {
+            return;
+        }
+
+        if (entry.isSync()) {
+            /**
+             * We are inserting a new timestamp because synchronized actions
+             * are always ran with a 50ms delay (1 game tick)
+             */
+            Slimefun.runSync(() -> {
+                ASlimefunDataContainer blockData = entry.getData();
+                if (blockData.isPendingRemove()) {
+                    return;
+                }
+                tickBlock(entry);
+            });
+        } else {
+            tickBlock(entry);
+        }
+    }
+
+    @ParametersAreNonnullByDefault
+    private void tickBlock(WaitingEntry entry) {
+        Location l = entry.location;
+        SlimefunItem item = entry.item;
+        ASlimefunDataContainer data = entry.data;
+        long timestamp = entry.timestamp;
         try {
-            if (item.getBlockTicker().isUniversal()) {
-                if (data instanceof SlimefunUniversalData universalData) {
-                    item.getBlockTicker().tick(l.getBlock(), item, universalData);
-                } else {
-                    throw new IllegalStateException("BlockTicker is universal but item is non-universal!");
-                }
-            } else {
-                if (data instanceof SlimefunBlockData blockData) {
-                    item.getBlockTicker().tick(l.getBlock(), item, blockData);
-                } else {
-                    throw new IllegalStateException("BlockTicker is non-universal but item is universal!");
-                }
-            }
+            CompletableFuture.runAsync(() -> {
+                        if (item.getBlockTicker().isUniversal()) {
+                            if (data instanceof SlimefunUniversalData universalData) {
+                                item.getBlockTicker().tick(l.getBlock(), item, universalData);
+                            } else {
+                                throw new IllegalStateException("BlockTicker is universal but item is non-universal!");
+                            }
+                        } else {
+                            if (data instanceof SlimefunBlockData blockData) {
+                                item.getBlockTicker().tick(l.getBlock(), item, blockData);
+                            } else {
+                                throw new IllegalStateException("BlockTicker is non-universal but item is universal!");
+                            }
+                        }
+                    })
+                    .get(10, TimeUnit.SECONDS);
         } catch (Exception | LinkageError x) {
             reportErrors(l, item, x);
         } finally {
@@ -249,6 +345,12 @@ public class TickerTask implements Runnable {
 
     @ParametersAreNonnullByDefault
     private void reportErrors(Location l, SlimefunItem item, Throwable x) {
+        if (x instanceof TimeoutException) {
+            Slimefun.logger().log(Level.SEVERE, "World: {0} X: {1} Y: {2} Z: {3} ({4})", new Object[] {
+                l.getWorld().getName(), l.getBlockX(), l.getBlockY(), l.getBlockZ(), item.getId()
+            });
+            Slimefun.logger().log(Level.SEVERE, "该方块对应的机器在上一个 Tick 中运行超过 10 秒，可能会导致粘液刻严重被拖慢！");
+        }
         BlockPosition position = new BlockPosition(l);
         int errors = bugs.getOrDefault(position, 0) + 1;
 
@@ -438,5 +540,83 @@ public class TickerTask implements Runnable {
         synchronized (tickingLocations) {
             tickingLocations.values().forEach(loc -> loc.removeIf(tk -> uuid.equals(tk.getUuid())));
         }
+    }
+
+    public void showWaitingList() {
+        showWaitingList(1);
+    }
+
+    public void showWaitingList(int page) {
+        var builder = Component.text()
+                .color(TextColor.color(0xFFD700))
+                .append(Component.text("===== Ticker 等待列表 ====="))
+                .appendNewline();
+
+        int j = 0;
+        for (var entry :
+                waiting.stream().skip((page - 1) * PAGE_SIZE).limit(PAGE_SIZE).toList()) {
+            int id = (page - 1) * PAGE_SIZE + j + 1;
+            String head = id + ". " + entry.item.getItemName() + " ";
+            builder.color(TextColor.color(0x00B7B7))
+                    .append(Component.text()
+                            .append(Component.text(head))
+                            .hoverEvent(Component.text("点击步过").clickEvent(ClickEvent.callback(p2 -> {
+                                for (int i = 0; i < id; i++) {
+                                    tickBlock();
+                                }
+                                showWaitingList();
+                            }))))
+                    .append(Component.text(" ".repeat(Math.max(0, 12 - head.length()))))
+                    .append(Component.text("[运行到] ")
+                            .hoverEvent(Component.text("点击运行到此并停止"))
+                            .clickEvent(ClickEvent.callback(p2 -> {
+                                for (int i = 0; i < id - 1; i++) {
+                                    tickBlock();
+                                }
+                                showWaitingList();
+                            })))
+                    .append(Component.text("[步过] ")
+                            .hoverEvent(Component.text("点击步过"))
+                            .clickEvent(ClickEvent.callback(p2 -> {
+                                for (int i = 0; i < id; i++) {
+                                    tickBlock();
+                                }
+                                showWaitingList();
+                            })))
+                    .append(Component.text("[高亮] ")
+                            .hoverEvent(Component.text("点击高亮方块"))
+                            .clickEvent(ClickEvent.callback(p2 -> {
+                                if (p2 instanceof Player p) {
+                                    ParticleUtil.highlightBlock(p, entry.getLocation(), 3);
+                                }
+                            })))
+                    .appendNewline();
+            j++;
+        }
+        int totalPage = (waiting.size() - 1) / PAGE_SIZE + 1;
+        builder.color(TextColor.color(0xFFD700))
+                .append(Component.text()
+                        .append(Component.text("=== 上一页 < ")
+                                .hoverEvent(Component.text("点击跳转到上一页 (" + (page - 1) + ")"))
+                                .clickEvent(ClickEvent.callback(p2 -> {
+                                    if (page - 1 < 1) {
+                                        return;
+                                    }
+                                    showWaitingList(page - 1);
+                                })))
+                        .append(Component.text(page + " / " + totalPage)
+                                .append(Component.text(" > 下一页 ===")
+                                        .hoverEvent(Component.text("点击跳转到下一页 (" + (page + 1) + ")"))
+                                        .clickEvent(ClickEvent.callback(p2 -> {
+                                            if (page + 1 > totalPage) {
+                                                return;
+                                            }
+                                            showWaitingList(page + 1);
+                                        })))));
+
+        Component text = builder.build();
+        Bukkit.getServer().getOnlinePlayers().stream().filter(Player::isOp).forEach(player -> {
+            player.sendMessage(text);
+        });
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -80,15 +80,15 @@ public class TickerTask implements Runnable {
     @Setter
     private volatile boolean paused = false;
 
-    private Deque<WaitingEntry> waiting = new ConcurrentLinkedDeque<>();
+    private final Deque<WaitingEntry> waiting = new ConcurrentLinkedDeque<>();
 
     private final int PAGE_SIZE = 10;
 
     @Setter
-    private boolean tickFreeze = false;
+    private volatile boolean tickFreeze = false;
 
     @Setter
-    private Predicate<WaitingEntry> tickFreezePredicate = entry -> false;
+    private volatile Predicate<WaitingEntry> tickFreezePredicate = entry -> false;
 
     @Data
     @AllArgsConstructor
@@ -342,6 +342,7 @@ public class TickerTask implements Runnable {
 
     @ParametersAreNonnullByDefault
     private void timedTickBlock(WaitingEntry entry, long timeout, TimeUnit timeUnit) {
+        if (entry.data.isPendingRemove()) return; // waiting 期间机器可能会被拆除
         Location l = entry.location;
         SlimefunItem item = entry.item;
         long timestamp = entry.timestamp;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -23,13 +23,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -91,13 +91,24 @@ public class TickerTask implements Runnable {
     private volatile Predicate<WaitingEntry> tickFreezePredicate = entry -> false;
 
     @Data
-    @AllArgsConstructor
     public static class WaitingEntry {
-        private Location location;
-        private SlimefunItem item;
-        private ASlimefunDataContainer data;
-        private long timestamp;
-        private boolean sync;
+        private static final AtomicLong ID = new AtomicLong(0);
+        private final Location location;
+        private final SlimefunItem item;
+        private final ASlimefunDataContainer data;
+        private final long timestamp;
+        private final boolean sync;
+        private final long id;
+
+        public WaitingEntry(
+                Location location, SlimefunItem item, ASlimefunDataContainer data, long timestamp, boolean sync) {
+            this.location = location;
+            this.item = item;
+            this.data = data;
+            this.timestamp = timestamp;
+            this.sync = sync;
+            this.id = ID.getAndIncrement();
+        }
     }
 
     /**
@@ -347,7 +358,7 @@ public class TickerTask implements Runnable {
         SlimefunItem item = entry.item;
         long timestamp = entry.timestamp;
         try {
-            if (Bukkit.isPrimaryThread()) {
+            if (entry.isSync()) {
                 // Bukkit 自带的 Watchdog 会检测超时，不需要我们处理
                 tickBlock(entry);
             } else {
@@ -594,13 +605,13 @@ public class TickerTask implements Runnable {
         int j = 0;
         for (var entry :
                 waiting.stream().skip((page - 1) * PAGE_SIZE).limit(PAGE_SIZE).toList()) {
-            int id = (page - 1) * PAGE_SIZE + j + 1;
-            String head = id + ". " + entry.item.getItemName() + " ";
+            int number = (page - 1) * PAGE_SIZE + j + 1;
+            String head = number + ". " + entry.item.getItemName() + " ";
             builder.color(TextColor.color(0x00B7B7))
                     .append(Component.text()
                             .append(Component.text(head))
                             .hoverEvent(Component.text("点击步过").clickEvent(ClickEvent.callback(p2 -> {
-                                for (int i = 0; i < id; i++) {
+                                while (!waiting.isEmpty() && waiting.peek().id <= entry.id) {
                                     timedTickBlock();
                                 }
                                 showWaitingList();
@@ -609,7 +620,7 @@ public class TickerTask implements Runnable {
                     .append(Component.text("[运行到] ")
                             .hoverEvent(Component.text("点击运行到此并停止"))
                             .clickEvent(ClickEvent.callback(p2 -> {
-                                for (int i = 0; i < id - 1; i++) {
+                                while (!waiting.isEmpty() && waiting.peek().id < entry.id) {
                                     timedTickBlock();
                                 }
                                 showWaitingList();
@@ -617,7 +628,7 @@ public class TickerTask implements Runnable {
                     .append(Component.text("[步过] ")
                             .hoverEvent(Component.text("点击步过"))
                             .clickEvent(ClickEvent.callback(p2 -> {
-                                for (int i = 0; i < id; i++) {
+                                while (!waiting.isEmpty() && waiting.peek().id <= entry.id) {
                                     timedTickBlock();
                                 }
                                 showWaitingList();
@@ -626,7 +637,12 @@ public class TickerTask implements Runnable {
                             .hoverEvent(Component.text("点击高亮方块"))
                             .clickEvent(ClickEvent.callback(p2 -> {
                                 if (p2 instanceof Player p) {
-                                    ParticleUtil.highlightBlock(p, entry.getLocation(), 3);
+                                    if (p.getLocation().getWorld()
+                                            == entry.getLocation().getWorld()) {
+                                        ParticleUtil.highlightBlock(p, entry.getLocation(), 3);
+                                    } else {
+                                        Slimefun.getLocalization().sendMessage(p, "messages.wrong-world");
+                                    }
                                 }
                             })))
                     .appendNewline();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -12,7 +12,6 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.ticker.TickLocation;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.ParticleUtil;
-import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
@@ -21,6 +20,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -43,6 +43,7 @@ import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitScheduler;
+import org.jetbrains.annotations.ApiStatus.Internal;
 
 /**
  * The {@link TickerTask} is responsible for ticking every {@link BlockTicker},
@@ -79,7 +80,7 @@ public class TickerTask implements Runnable {
     @Setter
     private volatile boolean paused = false;
 
-    private Deque<WaitingEntry> waiting = new ArrayDeque<>(256);
+    private Deque<WaitingEntry> waiting = new ConcurrentLinkedDeque<>();
 
     private final int PAGE_SIZE = 10;
 
@@ -137,7 +138,7 @@ public class TickerTask implements Runnable {
 
         int length = waiting.size();
         for (int i = 0; i < length; i++) {
-            tickBlock();
+            timedTickBlock();
         }
 
         try {
@@ -221,11 +222,11 @@ public class TickerTask implements Runnable {
                     Slimefun.getProfiler().scheduleEntries(1);
                     item.getBlockTicker().update();
 
-                    tickBlock(l, item, blockData, System.nanoTime(), true);
+                    timedTickBlock(l, item, blockData, System.nanoTime(), true);
                 } else {
                     long timestamp = Slimefun.getProfiler().newEntry();
                     item.getBlockTicker().update();
-                    tickBlock(l, item, blockData, timestamp, false);
+                    timedTickBlock(l, item, blockData, timestamp, false);
                 }
 
                 tickers.add(item.getBlockTicker());
@@ -258,12 +259,12 @@ public class TickerTask implements Runnable {
                         if (data.isPendingRemove()) {
                             return;
                         }
-                        tickBlock(l, item, data, System.nanoTime(), true);
+                        timedTickBlock(l, item, data, System.nanoTime(), true);
                     });
                 } else {
                     long timestamp = Slimefun.getProfiler().newEntry();
                     item.getBlockTicker().update();
-                    tickBlock(l, item, data, timestamp, false);
+                    timedTickBlock(l, item, data, timestamp, false);
                 }
 
                 tickers.add(item.getBlockTicker());
@@ -274,23 +275,24 @@ public class TickerTask implements Runnable {
     }
 
     @ParametersAreNonnullByDefault
-    private void tickBlock(Location l, SlimefunItem item, ASlimefunDataContainer data, long timestamp) {
-        tickBlock(l, item, data, timestamp, true); // fallback
+    private void timedTickBlock(Location l, SlimefunItem item, ASlimefunDataContainer data, long timestamp) {
+        timedTickBlock(l, item, data, timestamp, true); // fallback
     }
 
     @ParametersAreNonnullByDefault
-    private void tickBlock(Location l, SlimefunItem item, ASlimefunDataContainer data, long timestamp, boolean sync) {
+    private void timedTickBlock(
+            Location l, SlimefunItem item, ASlimefunDataContainer data, long timestamp, boolean sync) {
         var entry = new WaitingEntry(l, item, data, timestamp, sync);
         waiting.add(entry);
         if (tickFreezePredicate.test(entry)) {
             tickFreeze = true;
         }
         if (!tickFreeze) {
-            tickBlock();
+            timedTickBlock();
         }
     }
 
-    private void tickBlock() {
+    private void timedTickBlock() {
         WaitingEntry entry = waiting.poll();
         if (entry == null) {
             return;
@@ -306,36 +308,55 @@ public class TickerTask implements Runnable {
                 if (blockData.isPendingRemove()) {
                     return;
                 }
-                tickBlock(entry);
+                timedTickBlock(entry);
             });
         } else {
-            tickBlock(entry);
+            timedTickBlock(entry);
         }
     }
 
+    private void timedTickBlock(WaitingEntry entry) {
+        timedTickBlock(entry, 10, TimeUnit.SECONDS); // default timeout
+    }
+
+    @Internal
     @ParametersAreNonnullByDefault
     private void tickBlock(WaitingEntry entry) {
         Location l = entry.location;
         SlimefunItem item = entry.item;
         ASlimefunDataContainer data = entry.data;
+        if (item.getBlockTicker().isUniversal()) {
+            if (data instanceof SlimefunUniversalData universalData) {
+                item.getBlockTicker().tick(l.getBlock(), item, universalData);
+            } else {
+                throw new IllegalStateException("BlockTicker is universal but item is non-universal!");
+            }
+        } else {
+            if (data instanceof SlimefunBlockData blockData) {
+                item.getBlockTicker().tick(l.getBlock(), item, blockData);
+            } else {
+                throw new IllegalStateException("BlockTicker is non-universal but item is universal!");
+            }
+        }
+    }
+
+    @ParametersAreNonnullByDefault
+    private void timedTickBlock(WaitingEntry entry, long timeout, TimeUnit timeUnit) {
+        Location l = entry.location;
+        SlimefunItem item = entry.item;
         long timestamp = entry.timestamp;
         try {
-            CompletableFuture.runAsync(() -> {
-                        if (item.getBlockTicker().isUniversal()) {
-                            if (data instanceof SlimefunUniversalData universalData) {
-                                item.getBlockTicker().tick(l.getBlock(), item, universalData);
-                            } else {
-                                throw new IllegalStateException("BlockTicker is universal but item is non-universal!");
-                            }
-                        } else {
-                            if (data instanceof SlimefunBlockData blockData) {
-                                item.getBlockTicker().tick(l.getBlock(), item, blockData);
-                            } else {
-                                throw new IllegalStateException("BlockTicker is non-universal but item is universal!");
-                            }
-                        }
-                    })
-                    .get(10, TimeUnit.SECONDS);
+            if (Bukkit.isPrimaryThread()) {
+                // Bukkit 自带的 Watchdog 会检测超时，不需要我们处理
+                tickBlock(entry);
+            } else {
+                CompletableFuture.runAsync(() -> {
+                            tickBlock(entry);
+                        })
+                        .get(timeout, timeUnit);
+            }
+        } catch (TimeoutException e) {
+            reportTimeout(l, item, timeout, timeUnit, e);
         } catch (Exception | LinkageError x) {
             reportErrors(l, item, x);
         } finally {
@@ -343,14 +364,31 @@ public class TickerTask implements Runnable {
         }
     }
 
+    public static String getChineseTimeUnit(TimeUnit unit) {
+        return switch (unit) {
+            case NANOSECONDS -> "纳秒";
+            case MICROSECONDS -> "微秒";
+            case MILLISECONDS -> "毫秒";
+            case SECONDS -> "秒";
+            case MINUTES -> "分钟";
+            case HOURS -> "小时";
+            case DAYS -> "天";
+        };
+    }
+
+    private void reportTimeout(Location l, SlimefunItem item, long timeout, TimeUnit timeUnit, TimeoutException e) {
+        Slimefun.logger().log(Level.SEVERE, "World: {0} X: {1} Y: {2} Z: {3} ({4})", new Object[] {
+            l.getWorld().getName(), l.getBlockX(), l.getBlockY(), l.getBlockZ(), item.getId()
+        });
+        Slimefun.logger()
+                .log(
+                        Level.SEVERE,
+                        "该方块对应的机器在上一个 Tick 中运行超过 " + timeout + getChineseTimeUnit(timeUnit) + "，可能会导致粘液刻严重被拖慢！");
+        reportErrors(l, item, e);
+    }
+
     @ParametersAreNonnullByDefault
     private void reportErrors(Location l, SlimefunItem item, Throwable x) {
-        if (x instanceof TimeoutException) {
-            Slimefun.logger().log(Level.SEVERE, "World: {0} X: {1} Y: {2} Z: {3} ({4})", new Object[] {
-                l.getWorld().getName(), l.getBlockX(), l.getBlockY(), l.getBlockZ(), item.getId()
-            });
-            Slimefun.logger().log(Level.SEVERE, "该方块对应的机器在上一个 Tick 中运行超过 10 秒，可能会导致粘液刻严重被拖慢！");
-        }
         BlockPosition position = new BlockPosition(l);
         int errors = bugs.getOrDefault(position, 0) + 1;
 
@@ -562,7 +600,7 @@ public class TickerTask implements Runnable {
                             .append(Component.text(head))
                             .hoverEvent(Component.text("点击步过").clickEvent(ClickEvent.callback(p2 -> {
                                 for (int i = 0; i < id; i++) {
-                                    tickBlock();
+                                    timedTickBlock();
                                 }
                                 showWaitingList();
                             }))))
@@ -571,7 +609,7 @@ public class TickerTask implements Runnable {
                             .hoverEvent(Component.text("点击运行到此并停止"))
                             .clickEvent(ClickEvent.callback(p2 -> {
                                 for (int i = 0; i < id - 1; i++) {
-                                    tickBlock();
+                                    timedTickBlock();
                                 }
                                 showWaitingList();
                             })))
@@ -579,7 +617,7 @@ public class TickerTask implements Runnable {
                             .hoverEvent(Component.text("点击步过"))
                             .clickEvent(ClickEvent.callback(p2 -> {
                                 for (int i = 0; i < id; i++) {
-                                    tickBlock();
+                                    timedTickBlock();
                                 }
                                 showWaitingList();
                             })))

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ParticleUtil.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ParticleUtil.java
@@ -109,7 +109,7 @@ public class ParticleUtil {
     public static void highlightBlock(@NotNull Player player, @NotNull Location location, int shrinkTimes) {
         for (int i = 0; i < shrinkTimes; i++) {
             Bukkit.getScheduler()
-                    .runTaskLaterAsynchronously(
+                    .runTaskLater(
                             Slimefun.instance(),
                             () -> {
                                 drawLineFrom(player.getEyeLocation().clone().add(0D, -0.5D, 0D), location);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ParticleUtil.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ParticleUtil.java
@@ -1,0 +1,137 @@
+package io.github.thebusybiscuit.slimefun4.utils;
+
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Final_ROOT
+ * @author balugaq
+ */
+@SuppressWarnings("DuplicatedCode")
+public class ParticleUtil {
+    private static final double[] BLOCK_CUBE_OFFSET_X = new double[] {0, 1, 0, 0, 1, 1, 0, 1};
+    private static final double[] BLOCK_CUBE_OFFSET_Y = new double[] {0, 0, 1, 0, 1, 0, 1, 1};
+    private static final double[] BLOCK_CUBE_OFFSET_Z = new double[] {0, 0, 0, 1, 0, 1, 1, 1};
+
+    public static void drawLineByTotalAmount(
+            @NotNull Particle particle, int totalAmount, @NotNull Location @NotNull ... locations) {
+        for (int i = 0; i < locations.length; i++) {
+            if ((i + 1) < locations.length) {
+                Location location1 = locations[i];
+                Location location2 = locations[i + 1];
+
+                if (totalAmount < 1 || location1.getWorld() == null || location1.getWorld() != location2.getWorld()) {
+                    return;
+                }
+                World world = location1.getWorld();
+                double[] x = disperse(totalAmount, location1.getX(), location2.getX());
+                double[] y = disperse(totalAmount, location1.getY(), location2.getY());
+                double[] z = disperse(totalAmount, location1.getZ(), location2.getZ());
+                for (int j = 0; j < totalAmount; j++) {
+                    world.spawnParticle(particle, x[j], y[j], z[j], 1, 0, 0, 0, 0);
+                }
+            }
+        }
+    }
+
+    public static void drawCubeByBlock(
+            @NotNull final Plugin plugin,
+            @NotNull final Particle particle,
+            final long interval,
+            @NotNull final Block @NotNull ... blocks) {
+        int time = 0;
+        for (final Block block : blocks) {
+            final Location location = block.getLocation();
+            final World world = location.getWorld();
+            if (world == null) {
+                continue;
+            }
+            final int x = location.getBlockX();
+            final int y = location.getBlockY();
+            final int z = location.getBlockZ();
+            if (time < 50) {
+                for (int i = 0; i < BLOCK_CUBE_OFFSET_X.length; i++) {
+                    world.spawnParticle(
+                            particle,
+                            x + BLOCK_CUBE_OFFSET_X[i],
+                            y + BLOCK_CUBE_OFFSET_Y[i],
+                            z + BLOCK_CUBE_OFFSET_Z[i],
+                            1,
+                            0,
+                            0,
+                            0,
+                            0);
+                }
+            } else {
+                plugin.getServer()
+                        .getScheduler()
+                        .runTaskLaterAsynchronously(
+                                plugin,
+                                () -> {
+                                    for (int i = 0; i < BLOCK_CUBE_OFFSET_X.length; i++) {
+                                        world.spawnParticle(
+                                                particle,
+                                                x + BLOCK_CUBE_OFFSET_X[i],
+                                                y + BLOCK_CUBE_OFFSET_Y[i],
+                                                z + BLOCK_CUBE_OFFSET_Z[i],
+                                                1,
+                                                0,
+                                                0,
+                                                0,
+                                                0);
+                                    }
+                                },
+                                time / 50);
+            }
+            time += (int) interval;
+        }
+    }
+
+    public static void drawLineFrom(final @NotNull Location location1, final @NotNull Location location2) {
+        drawLineByTotalAmount(Particle.WAX_OFF, (int) location1.distance(location2) * 4, location1, location2);
+    }
+
+    public static void highlightBlock(final @NotNull Location location) {
+        highlightBlock(location.getBlock());
+    }
+
+    public static void highlightBlock(final Block block) {
+        drawCubeByBlock(Slimefun.instance(), Particle.WAX_ON, 1, block);
+    }
+
+    public static void highlightBlock(@NotNull Player player, @NotNull Location location, int shrinkTimes) {
+        for (int i = 0; i < shrinkTimes; i++) {
+            Bukkit.getScheduler()
+                    .runTaskLaterAsynchronously(
+                            Slimefun.instance(),
+                            () -> {
+                                drawLineFrom(player.getEyeLocation().clone().add(0D, -0.5D, 0D), location);
+                                highlightBlock(location);
+                            },
+                            20L * i);
+        }
+    }
+
+    public static double[] disperse(int size, Number @NotNull ... value) {
+        if (size == 1 && value.length > 0) {
+            return new double[] {value[0].doubleValue()};
+        } else if (size == 0 || value.length == 0) {
+            return new double[0];
+        }
+        double[] result = new double[size--];
+        for (int i = 0; i <= size; i++) {
+            double p = ((double) i) / size * (value.length - 1);
+            double value1 = value[(int) Math.floor(p)].doubleValue() * (1 - p + Math.floor(p));
+            double value2 = value[(int) Math.ceil(p)].doubleValue() * (p - Math.floor(p));
+            result[i] = value1 + value2;
+        }
+        return result;
+    }
+}

--- a/src/main/resources/languages/zh-CN/messages.yml
+++ b/src/main/resources/languages/zh-CN/messages.yml
@@ -287,6 +287,7 @@ messages:
   tick-freeze-predicate-reset: "&e已重置 Tick Freeze 自定义检测"
   tick-freeze-on: "开启"
   tick-freeze-off: "关闭"
+  wrong-world: "不在同一世界！无法高亮方块！"
 machines:
   pattern-not-found: '&e抱歉, 这不是正确的合成配方, 请检查发射器里放置物品的顺序.'
   unknown-material: '&e抱歉, 我无法识别在发射器里的物品. 请按照合成配方放置物品.'

--- a/src/main/resources/languages/zh-CN/messages.yml
+++ b/src/main/resources/languages/zh-CN/messages.yml
@@ -69,6 +69,8 @@ commands:
     in-progress: "&a迁移正在进行中..."
   blockdata:
     description: '操作粘液方块数据'
+  tick:
+    description: "操作粘液刻断点"
 placeholderapi:
   profile-loading: '加载中...'
 guide:
@@ -164,6 +166,8 @@ actionbar:
   radiation: '&6辐射暴露等级：&c%level%&7/&e100'
 
 messages:
+  tick-rate: "Tick rate: %tick-rate%"
+  tick-query: "Tick Freeze: %mode%, Tick rate: %tick-rate%"
   android-no-permission: "&c你的机器人在某个你没有权限的领地/地皮中无法工作, 机器人已自动暂停运行."
   not-researched: '&4你的知识还不足以理解这个物品. &c你需要先解锁 &f"%item%"&f'
   not-enough-xp: '&4你没有足够的经验来解锁这个研究'
@@ -277,6 +281,12 @@ messages:
   above-limit-level: '&c你要附/祛魔物品的附魔等级超过了 %level% 级!'
   pickaxe-of-the-seeker:
     no-ores: '&c附近找不到任何矿石!'
+  tick-mode: "&eTick Freeze: %mode%"
+  not-found: "&c无效的参数"
+  not-a-number: "&c请输入一个数字"
+  tick-freeze-predicate-reset: "&e已重置 Tick Freeze 自定义检测"
+  tick-freeze-on: "开启"
+  tick-freeze-off: "关闭"
 machines:
   pattern-not-found: '&e抱歉, 这不是正确的合成配方, 请检查发射器里放置物品的顺序.'
   unknown-material: '&e抱歉, 我无法识别在发射器里的物品. 请按照合成配方放置物品.'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -110,3 +110,6 @@ permissions:
   slimefun.debugging:
     description: Allows you to use the debugging tool from Slimefun
     default: op
+  slimefun.command.tick:
+    description: Allows you to do /sf tick
+    default: op


### PR DESCRIPTION
上个 PR：https://github.com/SlimefunGuguProject/Slimefun4/pull/1215 （pull 错分支了乱套了，遂重新上传）

此 PR 添加了 `/sf tick` 指令，旨在方便地对粘液刻运行打断点，便于调试机器时序运行测试bug等。
并添加了 tick 执行超时检测（10 秒），避免死循环不退出 tick 执行。

命令基础：
- 根命令：`/sf tick`
- 权限节点：slimefun.command.tick（控制台无需权限）
- 适用对象：玩家或控制台

一、无额外参数
`/sf tick`
功能：切换全局 Tick 冻结模式（开启 ↔ 关闭）
效果：发送 messages.tick-mode，显示当前是“开启”还是“关闭”

二、两个参数（/sf tick <参数>）
`/sf tick show`
功能：显示当前正在等待 Tick 的物品列表

`/sf tick freeze`
功能：开启全局 Tick 冻结（所有机器停止工作）

`/sf tick unfreeze`
功能：关闭全局 Tick 冻结（恢复正常）

`/sf tick query`
功能：查询当前 Tick 冻结状态和 Tick 速率（isTickFreeze + getTickRate）

`/sf tick at`
功能：仅玩家可用。冻结玩家准星指向的方块（距离 ≤ 8 格）或主手持有的 Slimefun 物品。若目标既不是机器也不是物品，则提示 not-found

`/sf tick <SlimefunItemID>`
功能：冻结指定 ID 的 Slimefun 物品（如 BASIC_CIRCUIT_BOARD）。ID 自动转为大写匹配

三、三个参数（速率设置）
`/sf tick rate <数字>`
功能：设置 Tick 的执行间隔（单位：游戏刻，20 tick = 1 秒）
示例：/sf tick rate 10 → 每 10 tick 执行一次
异常：若 <数字> 非整数，提示 not-a-number

四、坐标参数（冻结指定位置的方块）
- 使用当前世界的坐标（4 个参数）：
  `/sf tick <x> <y> <z>`
  世界取当前发送者所在的世界（控制台默认为 "world"）
- 指定世界的坐标（5 个参数）：
  `/sf tick <世界名> <x> <y> <z>`
  示例：/sf tick world_nether 100 64 -200
功能：仅冻结该坐标方块的 Tick

帮助信息：
当参数模式无法匹配上述任何一条时，发送 messages.usage，提示：
`/sf tick (<x> <y> <z> | <Slimefun Item>)`

无权限提示：
若玩家没有权限且不是控制台，发送 messages.no-permission

在启动 Tick 冻结（`/sf tick freeze`）后，管理员可以使用 `/sf tick show` 查看当前被阻塞的 Slimefun 机器/物品等待列表，并针对列表中的条目进行逐步执行、跳转执行或位置高亮等调试操作。

本功能（showWaitingList）的行为描述如下：

1. 分页显示等待队列
   - 每页显示 PAGE_SIZE 个条目（通常为 10）
   - 显示格式：序号 + 物品名称 + 操作按钮
   - 支持上一页/下一页翻页（点击文字跳转）

2. 每个条目提供三种可点击的操作（悬浮提示）：
   - “步过”：从队列头部开始依次执行该序号之前的所有 Tick（包含本条目），执行后刷新列表
   - “运行到”：执行到本条目之前停止（即执行前 id-1 个 Tick），然后刷新列表
   - “高亮”：若发送者为玩家，则在对应方块位置生成粒子效果高亮显示 3 秒（用于定位机器）

3. 操作执行逻辑
   - “步过”与“运行到”都会调用 tickBlock() 方法依次处理指定数量的等待项
   - 执行完毕后自动重新调用 showWaitingList() 刷新列表

4. 权限与接收者
   - 只有服务器管理员（OP）且在线玩家才能收到该交互式消息
   - 消息使用 MiniMessage 格式，支持点击事件和悬浮提示

使用场景：当全局 Tick 冻结后，管理员可以通过该命令观察仍有待处理任务的机器队列，并有选择地逐步执行某些机器的 Tick 任务，便于排查问题或手动推进流程。

- **Generated by DeepSeek*

<img width="515" height="310" alt="QQ_1780213673119" src="https://github.com/user-attachments/assets/7358767a-fdd0-447e-8825-d7ef16075674" />